### PR TITLE
Adds loaderStyle prop to allow for inner styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ class AwesomeComponent extends React.Component {
     return (
       <div className='sweet-loading'>
         <ClipLoader
-          loaderStyle={{display: "block", margin: "0 auto"}}
+          loaderStyle={{display: "block", margin: "0 auto", borderColor: 'red'}}
           color={'#123abc'}
           loading={this.state.loading}
         />
@@ -110,7 +110,9 @@ color: '#000000'
 loaderStyle: {}
 ```
 Note:
-For loaderStyle, the resulting CSS will be the combination of the default props and the newly passed in CSS. This typically adjusts the CSS of the wrapper of the loader, not the actual loader properties themselves.
+For loaderStyle, the resulting css will be the combination of the default props and the newly passed in css. This typically adjusts the css of the wrapper of the loader, not the actual loader properties themselves.  
+Instead of writing css properties in kebab-case like regular css, you write them in camelCase, for example background-color would be backgroundColor. You can find out more details [here](https://emotion.sh/docs/object-styles).
+
 
 Loader                  | size:int | height:int | width:int | radius:int | margin:str
 -----------------------:|:--------:|:----------:|:---------:|:----------:|:---------:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Each loader accepts a `loading` prop as a boolean. The loader will not render an
 }
 ```
 
-### Example
-
+### Examples
+Ring Loader
 ```js
 import React from 'react';
 import { RingLoader } from 'react-spinners';
@@ -66,7 +66,39 @@ class AwesomeComponent extends React.Component {
     )
   }
 }
+```  
+
+
+<details><summary>Clip Loader with Custom CSS</summary>
+<p>
+
+```js
+import React from 'react';
+import { RingLoader } from 'react-spinners';
+
+class AwesomeComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true
+    }
+  }
+  render() {
+    return (
+      <div className='sweet-loading'>
+        <ClipLoader
+          loaderStyle={{display: "block", margin: "0 auto"}}
+          color={'#123abc'}
+          loading={this.state.loading}
+        />
+      </div> 
+    )
+  }
+}
 ```
+
+</p>
+</details>
 
 ## Available Loaders, PropTypes, and Default Values
 
@@ -75,7 +107,10 @@ Common default props for all loaders:
 ```js
 loading: true
 color: '#000000'
+loaderStyle: {}
 ```
+Note:
+For loaderStyle, the resulting CSS will be the combination of the default props and the newly passed in CSS. This typically adjusts the CSS of the wrapper of the loader, not the actual loader properties themselves.
 
 Loader                  | size:int | height:int | width:int | radius:int | margin:str
 -----------------------:|:--------:|:----------:|:---------:|:----------:|:---------:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class AwesomeComponent extends React.Component {
 ```  
 
 
-<details><summary>Clip Loader with Custom CSS</summary>
+<details><summary>Clip Loader with Custom CSS, and Size</summary>
 <p>
 
 ```js
@@ -88,6 +88,8 @@ class AwesomeComponent extends React.Component {
       <div className='sweet-loading'>
         <ClipLoader
           loaderStyle={{display: "block", margin: "0 auto", borderColor: 'red'}}
+          sizeUnit={"px"}
+          size={"150"}
           color={'#123abc'}
           loading={this.state.loading}
         />

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,5 @@
+import { css, cx } from 'emotion';
+
 export const calculateRgba = (color, opacity) => {
   if (color[0] === '#') {
     color = color.slice(1);
@@ -14,4 +16,12 @@ export const calculateRgba = (color, opacity) => {
 
   let rgbValues = color.match(/.{2}/g).map(hex => parseInt(hex, 16)).join(', ');
   return `rgba(${rgbValues}, ${opacity})`;
+};
+
+export const styleLoader = (defaultStyle, loaderStyle) => {
+  if (Object.keys(loaderStyle).length === 0) {
+    return defaultStyle;
+  } else {
+    return cx(defaultStyle, css(loaderStyle));
+  }
 };

--- a/src/spinners/BarLoader.jsx
+++ b/src/spinners/BarLoader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
-import { calculateRgba } from '../helpers';
+import { calculateRgba, styleLoader } from '../helpers';
 
 const long = keyframes`
   0% {left: -35%;right: 100%} 
@@ -41,7 +41,7 @@ export class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
       </div> : null;
@@ -49,6 +49,7 @@ export class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   width: PropTypes.number,
@@ -58,6 +59,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   width: 100,
@@ -66,6 +68,6 @@ Loader.defaultProps = {
   heightUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'width', 'height', 'heightUnit', 'widthUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'width', 'height', 'heightUnit', 'widthUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/BeatLoader.jsx
+++ b/src/spinners/BeatLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const beat = keyframes`
   50% {transform: scale(0.75);opacity: 0.2} 
@@ -19,9 +20,13 @@ class Loader extends React.Component {
         animation: ${beat} 0.7s ${i % 2 ? '0s' : '0.35s'} infinite linear;
         animation-fill-mode: both;
     }`;
+
+  wrapper = () => css`{        
+    }`
+  ;
   render() {
     return this.props.loading ?
-      <div>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
         <div className={this.style(3)} />
@@ -30,6 +35,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -38,6 +44,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -45,6 +52,6 @@ Loader.defaultProps = {
   margin: '2px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/BounceLoader.jsx
+++ b/src/spinners/BounceLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const bounce = keyframes`
   0%, 100% {transform: scale(0)} 
@@ -29,7 +30,7 @@ class Loader extends React.Component {
     }`;
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
       </div> : null;
@@ -37,6 +38,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -44,12 +46,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 60,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/CircleLoader.jsx
+++ b/src/spinners/CircleLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const circle = keyframes`
   0% {transform: rotate(0deg)} 
@@ -33,7 +34,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(0)} />
         <div className={this.style(1)} />
         <div className={this.style(2)} />
@@ -44,6 +45,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -51,13 +53,14 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 50,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;
 

--- a/src/spinners/ClimbingBoxLoader.jsx
+++ b/src/spinners/ClimbingBoxLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const climbingBox = keyframes`
   0% {transform:translate(0, -1em) rotate(-45deg)} 
@@ -63,7 +64,7 @@ class Loader extends React.Component {
   render() {
     return this.props.loading ?
       <div className={this.container}>
-        <div className={this.wrapper()}>
+        <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
           <div className={this.style()} />
           <div className={this.hill()} />
         </div>
@@ -72,6 +73,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -79,12 +81,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/ClipLoader.jsx
+++ b/src/spinners/ClipLoader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { keyframes, css } from 'emotion';
+import { keyframes, css, cx } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
 
 // This returns an animation
@@ -11,7 +11,7 @@ const clip = keyframes`
 `;
 
 class Loader extends React.Component {
-  style = () => css`{
+  style = () => css`
         background: transparent !important;
         width: ${this.props.size + this.props.sizeUnit};
         height: ${this.props.size + this.props.sizeUnit};
@@ -22,14 +22,13 @@ class Loader extends React.Component {
         display: inline-block;
         animation: ${clip} 0.75s 0s infinite linear;
         animation-fill-mode: both;
-    }`;
-
+  `;
   render() {
-    return this.props.loading ? <div className={this.style()} /> : null;
+    return (this.props.loading ? <div className={Object.keys(this.props.loaderStyle).length === 0 ? this.style() : cx(this.style(), css(this.props.loaderStyle))} /> : null);
   }
 }
-
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -37,12 +36,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 35,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/ClipLoader.jsx
+++ b/src/spinners/ClipLoader.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { keyframes, css, cx } from 'emotion';
+import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 // This returns an animation
 const clip = keyframes`
@@ -24,7 +25,9 @@ class Loader extends React.Component {
         animation-fill-mode: both;
   `;
   render() {
-    return (this.props.loading ? <div className={Object.keys(this.props.loaderStyle).length === 0 ? this.style() : cx(this.style(), css(this.props.loaderStyle))} /> : null);
+    return this.props.loading ?
+      <div className={styleLoader(this.style(), this.props.loaderStyle)} />
+      : null;
   }
 }
 Loader.propTypes = {

--- a/src/spinners/DotLoader.jsx
+++ b/src/spinners/DotLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const rotate = keyframes`
   100% {transform: rotate(360deg)}
@@ -35,7 +36,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
       </div> : null;
@@ -43,6 +44,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -50,12 +52,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 60,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/FadeLoader.jsx
+++ b/src/spinners/FadeLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const fade = keyframes`
   50% {opacity: 0.3} 
@@ -82,7 +83,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.a()} />
         <div className={this.b()} />
         <div className={this.c()} />
@@ -96,6 +97,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   height: PropTypes.number,
@@ -108,6 +110,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   height: 15,
@@ -119,6 +122,6 @@ Loader.defaultProps = {
   radiusUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'height', 'width', 'margin', 'radius', 'widthUnit', 'heightUnit', 'radiusUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'height', 'width', 'margin', 'radius', 'widthUnit', 'heightUnit', 'radiusUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/GridLoader.jsx
+++ b/src/spinners/GridLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const grid = keyframes`
   0% {transform: scale(1)}
@@ -30,7 +31,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(random(100))} />
         <div className={this.style(random(100))} />
         <div className={this.style(random(100))} />
@@ -45,6 +46,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -53,6 +55,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -60,7 +63,7 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;
 

--- a/src/spinners/HashLoader.jsx
+++ b/src/spinners/HashLoader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
-import { calculateRgba } from '../helpers';
+import { calculateRgba, styleLoader } from '../helpers';
 
 
 class Loader extends React.Component {
@@ -45,7 +45,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
       </div> : null;
@@ -53,6 +53,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   size: PropTypes.number,
   color: PropTypes.string,
@@ -60,13 +61,14 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   size: 50,
   color: '#000000',
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;
 

--- a/src/spinners/MoonLoader.jsx
+++ b/src/spinners/MoonLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const moon = keyframes`
   100% {transform: rotate(360deg)}
@@ -43,7 +44,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.style(), this.props.loaderStyle)}>
         <div className={this.ball()} />
         <div className={this.circle()} />
       </div> : null;
@@ -51,6 +52,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -58,12 +60,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 60,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/PacmanLoader.jsx
+++ b/src/spinners/PacmanLoader.jsx
@@ -23,15 +23,15 @@ class Loader extends React.Component {
     `;
 
   ballStyle = i => css`{
-        width: 10px;
-        height: 10px;
+        width: ${(this.props.size / 2.5).toString() + this.props.sizeUnit};
+        height: ${(this.props.size / 2.5).toString() + this.props.sizeUnit};
         background-color: ${this.props.color};
         margin: ${this.props.margin};
         border-radius: 100%;
         transform: translate(0, ${(-this.props.size / 4).toString() + this.props.sizeUnit});
         position: absolute;
-        top: 25px;
-        left: 100px;
+        top: ${this.props.size.toString() + this.props.sizeUnit};
+        left: ${(this.props.size * 4).toString() + this.props.sizeUnit};
         animation: ${this.ball()} 1s ${i * 0.25}s infinite linear;
         animation-fill-mode: both;
     }`;

--- a/src/spinners/PacmanLoader.jsx
+++ b/src/spinners/PacmanLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 // This returns an animation
 const pacman = [
@@ -62,7 +63,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.pac()} />
         <div className={this.man()} />
         <div className={this.ballStyle(2)} />
@@ -74,6 +75,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -82,6 +84,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 25,
@@ -89,6 +92,6 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/PropagateLoader.jsx
+++ b/src/spinners/PropagateLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 // 1.5 4.5 7.5
 let distance = [1, 3, 5];
@@ -62,7 +63,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(0)} />
         <div className={this.style(1)} />
         <div className={this.style(2)} />
@@ -74,6 +75,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   size: PropTypes.number,
   color: PropTypes.string,
@@ -81,12 +83,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   size: 15,
   color: '#000000',
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/PulseLoader.jsx
+++ b/src/spinners/PulseLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 // This returns an animation
 const pulse = keyframes`
@@ -22,17 +23,20 @@ class Loader extends React.Component {
         animation-fill-mode: both;
     }`;
 
-  render() {
-    return this.props.loading ?
-      <div>
-        <div className={this.style(1)} />
-        <div className={this.style(2)} />
-        <div className={this.style(3)} />
-      </div> : null;
-  }
+    wrapper = () => css`{        
+    }`;
+    render() {
+      return this.props.loading ?
+        <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
+          <div className={this.style(1)} />
+          <div className={this.style(2)} />
+          <div className={this.style(3)} />
+        </div> : null;
+    }
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -41,6 +45,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -48,6 +53,6 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/RingLoader.jsx
+++ b/src/spinners/RingLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const right = keyframes`
   0% {transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg)}
@@ -37,7 +38,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
       </div> : null;
@@ -45,6 +46,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -52,6 +54,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 60,

--- a/src/spinners/RiseLoader.jsx
+++ b/src/spinners/RiseLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const riseAmount = 30;
 
@@ -33,9 +34,12 @@ class Loader extends React.Component {
         animation-fill-mode: both;
     }`;
 
+  wrapper = () => css`{        
+    }`;
+
   render() {
     return this.props.loading ?
-      <div>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
         <div className={this.style(3)} />
@@ -46,6 +50,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -54,6 +59,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -61,6 +67,6 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/RotateLoader.jsx
+++ b/src/spinners/RotateLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const rotate = keyframes`
   0% {transform: rotate(0deg)}
@@ -44,7 +45,7 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.wrapper()}>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.long()} />
         <div className={this.short()} />
       </div> : null;
@@ -52,6 +53,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -60,6 +62,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -67,6 +70,6 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/ScaleLoader.jsx
+++ b/src/spinners/ScaleLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const scale = keyframes`
   0% {transform: scaley(1.0)}
@@ -21,9 +22,13 @@ class Loader extends React.Component {
         animation-fill-mode: both;
     }`;
 
+  wrapper = () => css`{        
+    }`;
+
+
   render() {
     return this.props.loading ?
-      <div>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
         <div className={this.style(3)} />
@@ -34,6 +39,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   height: PropTypes.number,
@@ -46,6 +52,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   height: 35,
@@ -57,6 +64,6 @@ Loader.defaultProps = {
   radiusUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'height', 'width', 'margin', 'radius', 'heightUnit', 'widthUnit', 'radiusUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'height', 'width', 'margin', 'radius', 'heightUnit', 'widthUnit', 'radiusUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/SkewLoader.jsx
+++ b/src/spinners/SkewLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const skew = keyframes`
   25% {transform: perspective(100px) rotateX(180deg) rotateY(0)}
@@ -22,14 +23,18 @@ class Loader extends React.Component {
         animation-fill-mode: both;
     }`;
 
+  wrapper = () => css`{        
+    }`
 
   render() {
     return this.props.loading ?
-      <div className={this.style()} /> : null;
+      <div className={styleLoader(this.style(), this.props.loaderStyle)} />
+      : null;
   }
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -37,12 +42,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 20,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/SquareLoader.jsx
+++ b/src/spinners/SquareLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const square = keyframes`
   25% {transform: rotateX(180deg) rotateY(0)}
@@ -22,11 +23,13 @@ class Loader extends React.Component {
 
   render() {
     return this.props.loading ?
-      <div className={this.style()} /> : null;
+      <div className={styleLoader(this.style(), this.props.loaderStyle)} />
+      : null;
   }
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -34,12 +37,13 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 50,
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;

--- a/src/spinners/SyncLoader.jsx
+++ b/src/spinners/SyncLoader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
 import { onlyUpdateForKeys } from 'recompose';
+import { styleLoader } from '../helpers';
 
 const sync = keyframes`
   33% {transform: translateY(10px)}
@@ -21,9 +22,13 @@ class Loader extends React.Component {
         animation-fill-mode: both;
     }`;
 
+  wrapper = () => css`{        
+    }`
+  ;
+
   render() {
     return this.props.loading ?
-      <div>
+      <div className={styleLoader(this.wrapper(), this.props.loaderStyle)}>
         <div className={this.style(1)} />
         <div className={this.style(2)} />
         <div className={this.style(3)} />
@@ -32,6 +37,7 @@ class Loader extends React.Component {
 }
 
 Loader.propTypes = {
+  loaderStyle: PropTypes.shape(),
   loading: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.number,
@@ -40,6 +46,7 @@ Loader.propTypes = {
 };
 
 Loader.defaultProps = {
+  loaderStyle: {},
   loading: true,
   color: '#000000',
   size: 15,
@@ -47,6 +54,6 @@ Loader.defaultProps = {
   sizeUnit: 'px'
 };
 
-const Component = onlyUpdateForKeys(['loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
+const Component = onlyUpdateForKeys(['loaderStyle', 'loading', 'color', 'size', 'margin', 'sizeUnit'])(Loader);
 Component.defaultProps = Loader.defaultProps;
 export default Component;


### PR DESCRIPTION
This is a preliminary proposal to allow for inner styling on the loaders.

This resolves Issue #2 Issue #29? , and is a successor to PR #3 

Please make any recommendations, and once agreed upon, I will apply this for the rest of the loaders.

CX is used so that users can set their positioning without affecting the default props,
