### PR TITLE
fix Readme example and CONTRIBUTING prepublish

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Install the necessary dependencies (you can use `npm` or `yarn`):
 
 After finishing your feature, to update the `dist` folder, you can run:
 
-    npm prepublish
+    npm run prepublish
 
 If you want to make changes to the demo page, you can edit the files in `examples` and `docs` folder.
 To see the changes, you can use `webpack` to update the bundle file.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ class AwesomeComponent extends React.Component {
         <ClipLoader
           loaderStyle={{display: "block", margin: "0 auto", borderColor: 'red'}}
           sizeUnit={"px"}
-          size={"150"}
+          size={150}
           color={'#123abc'}
           loading={this.state.loading}
         />


### PR DESCRIPTION
The Clip Loader example had the wrong prop types:
`Warning: Failed prop type: Invalid prop 'size' of type 'string' supplied to 'Loader', expected 'number'.`

Also, the CONTRIBUTING docs were missing `run` or `run-script` for the prepublish step, so I added that.

