### PR TITLE
build: removes unnecessary generic import for recompose utility

### DIFF
--- a/src/BarLoader.jsx
+++ b/src/BarLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import { calculateRgba } from './helpers/index';
 
 const long = keyframes`

--- a/src/BeatLoader.jsx
+++ b/src/BeatLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const beat = keyframes`
   50% {transform: scale(0.75);opacity: 0.2} 

--- a/src/BounceLoader.jsx
+++ b/src/BounceLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const bounce = keyframes`
   0%, 100% {transform: scale(0)} 

--- a/src/CircleLoader.jsx
+++ b/src/CircleLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const circle = keyframes`
   0% {transform: rotate(0deg)} 

--- a/src/ClimbingBoxLoader.jsx
+++ b/src/ClimbingBoxLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const climbingBox = keyframes`
   0% {transform:translate(0, -1em) rotate(-45deg)} 

--- a/src/ClipLoader.jsx
+++ b/src/ClipLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 // This returns an animation
 const clip = keyframes`

--- a/src/DotLoader.jsx
+++ b/src/DotLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const rotate = keyframes`
   100% {transform: rotate(360deg)}

--- a/src/FadeLoader.jsx
+++ b/src/FadeLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const fade = keyframes`
   50% {opacity: 0.3} 

--- a/src/GridLoader.jsx
+++ b/src/GridLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const grid = keyframes`
   0% {transform: scale(1)}

--- a/src/HashLoader.jsx
+++ b/src/HashLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 import { calculateRgba } from './helpers/index';
 
 

--- a/src/MoonLoader.jsx
+++ b/src/MoonLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const moon = keyframes`
   100% {transform: rotate(360deg)}

--- a/src/PacmanLoader.jsx
+++ b/src/PacmanLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 // This returns an animation
 const pacman = [

--- a/src/PropagateLoader.jsx
+++ b/src/PropagateLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 // 1.5 4.5 7.5
 let distance = [1, 3, 5];

--- a/src/PulseLoader.jsx
+++ b/src/PulseLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 // This returns an animation
 const pulse = keyframes`

--- a/src/RingLoader.jsx
+++ b/src/RingLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const right = keyframes`
   0% {transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg)}

--- a/src/RiseLoader.jsx
+++ b/src/RiseLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const riseAmount = 30;
 

--- a/src/RotateLoader.jsx
+++ b/src/RotateLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const rotate = keyframes`
   0% {transform: rotate(0deg)}

--- a/src/ScaleLoader.jsx
+++ b/src/ScaleLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const scale = keyframes`
   0% {transform: scaley(1.0)}

--- a/src/SkewLoader.jsx
+++ b/src/SkewLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const skew = keyframes`
   25% {transform: perspective(100px) rotateX(180deg) rotateY(0)}

--- a/src/SquareLoader.jsx
+++ b/src/SquareLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const square = keyframes`
   25% {transform: rotateX(180deg) rotateY(0)}

--- a/src/SyncLoader.jsx
+++ b/src/SyncLoader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { keyframes, css } from 'emotion';
-import { onlyUpdateForKeys } from 'recompose';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const sync = keyframes`
   33% {transform: translateY(10px)}


### PR DESCRIPTION
**Before submitting a pull request,** please do the following:

1. Make sure you are not working on the master branch.
 - Since this comes from a fork, I guess it is ok to work in my master branch :P 

2. run `npm run test` and ensure that all tests pass:
 - Tests are passing.

3. Push up the branch code and create a pull request.
 - Okidoki, there you go!

4. Add details regarding what code you wrote.
 - I basically removed unnecessary imports for the generic recompose package. Currently importing `react-spinners` means also adding an extra recompose bundle of 12kb, even thou you're already using it in the project. This makes it more specific and more proper for tree-shaking.

5. If the pull request is related to a particular issue, make sure to reference the issue number.
 - There is no issue regarding this.
