### PR TITLE
Allow a wider range of Recompose versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,21 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -1620,6 +1635,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -2194,7 +2210,8 @@
     "core-js": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5633,11 +5650,11 @@
       }
     },
     "recompose": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
-      "integrity": "sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.0.0",
         "change-emitter": "^0.1.2",
         "fbjs": "^0.8.1",
         "hoist-non-react-statics": "^2.3.1",
@@ -5654,7 +5671,8 @@
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "emotion": "^9.1.1",
     "prop-types": "^15.5.10",
     "react-emotion": "^9.1.1",
-    "recompose": "0.27.1"
+    "recompose": "0.27.1 - 0.30.0"
   }
 }


### PR DESCRIPTION
A project I am working on uses both react-spinners and recompose, and currently we're either locked to using the version that react-spinners requires, or duplicate the recompose code in our bundle. Looking at the library's usage, I cannot find any reason react-spinner is locked to the recompose version (the `onlyUpdateForKeys` function that it uses has not changed in 2 years, and the functions that `onlyUpdateForKeys` depends appear to have been stable for a long time, too).

After making the change I ran the demo page locally and it looks to be functioning correctly to me with no errors in the console.

Note: Recompose is no longer going to receive feature updates, so it likely will never see a version past 0.30.0.