### PR TITLE
Add missing closing quote in sample .babelrc config in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each loader accepts a `loading` prop as a boolean. The loader will not render an
 
 ```
 {
-    "presets": ["@babel/preset-react", "@babel/preset-env],
+    "presets": ["@babel/preset-react", "@babel/preset-env"],
     "plugins": ["emotion"]
 }
 ```


### PR DESCRIPTION
No functionality changes, but fixes missing closing quote in .babelrc config from README.