### PR TITLE
Fix main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "progress",
     "activity"
   ],
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
     "prepare": "./node_modules/.bin/tsc",
     "test": "npm run lint",


### PR DESCRIPTION
While looking in the [Codesandbox compatibility issue](https://github.com/davidhu2000/react-spinners/issues/56) I realized that the package.json file specified `"main": "dist/index.js"` even though this dist folder is not created during prepare (built files are rather put at the root).

This PR just updates the main to point to the right file.

This should also fix the codesandbox issue as it will now know where the built files are.
