### PR TITLE
Remove recompose from dependencies

### DIFF
--- a/__tests__/__snapshots__/BarLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BarLoader-tests.tsx.snap
@@ -74,7 +74,7 @@ exports[`BarLoader should match snapshot 1`] = `
   animation: animation-1 2.1s 1.15s cubic-bezier(0.165,0.84,0.44,1) infinite;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   height={4}
@@ -83,25 +83,15 @@ exports[`BarLoader should match snapshot 1`] = `
   width={100}
   widthUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    height={4}
-    heightUnit="px"
-    loading={true}
-    width={100}
-    widthUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
@@ -59,7 +59,7 @@ exports[`BeatLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -67,27 +67,18 @@ exports[`BeatLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-3"
   >
     <div
-      className="emotion-3"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-0"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-0"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
@@ -65,30 +65,22 @@ exports[`BounceLoader should match snapshot 1`] = `
   animation: animation-0 2.1s 0s infinite ease-in-out;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={60}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={60}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
@@ -197,39 +197,31 @@ exports[`CircleLoader should match snapshot 1`] = `
   animation: animation-0 1s 0.8s infinite linear;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={50}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={50}
-    sizeUnit="px"
+  <div
+    className="emotion-5"
   >
     <div
-      className="emotion-5"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-      <div
-        className="emotion-3"
-      />
-      <div
-        className="emotion-4"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+    <div
+      className="emotion-3"
+    />
+    <div
+      className="emotion-4"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
@@ -116,34 +116,26 @@ exports[`ClimbingBoxLoader should match snapshot 1`] = `
   transform: rotate(45deg);
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-3"
   >
     <div
-      className="emotion-3"
+      className="emotion-2"
     >
       <div
-        className="emotion-2"
-      >
-        <div
-          className="emotion-0"
-        />
-        <div
-          className="emotion-1"
-        />
-      </div>
+        className="emotion-0"
+      />
+      <div
+        className="emotion-1"
+      />
     </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
@@ -36,23 +36,15 @@ exports[`ClipLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={35}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={35}
-    sizeUnit="px"
-  >
-    <div
-      className="emotion-0"
-    />
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+  <div
+    className="emotion-0"
+  />
+</Loader>
 `;

--- a/__tests__/__snapshots__/DotLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/DotLoader-tests.tsx.snap
@@ -75,30 +75,22 @@ exports[`DotLoader should match snapshot 1`] = `
   animation: animation-1 2s -1s infinite linear;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={60}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={60}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
@@ -244,7 +244,7 @@ exports[`FadeLoader should match snapshot 1`] = `
   transform: rotate(45deg);
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   height={15}
@@ -256,46 +256,33 @@ exports[`FadeLoader should match snapshot 1`] = `
   width={5}
   widthUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    height={15}
-    heightUnit="px"
-    loading={true}
-    margin="2px"
-    radius={2}
-    radiusUnit="px"
-    width={5}
-    widthUnit="px"
+  <div
+    className="emotion-8"
   >
     <div
-      className="emotion-8"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-      <div
-        className="emotion-3"
-      />
-      <div
-        className="emotion-4"
-      />
-      <div
-        className="emotion-5"
-      />
-      <div
-        className="emotion-6"
-      />
-      <div
-        className="emotion-7"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+    <div
+      className="emotion-3"
+    />
+    <div
+      className="emotion-4"
+    />
+    <div
+      className="emotion-5"
+    />
+    <div
+      className="emotion-6"
+    />
+    <div
+      className="emotion-7"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/GridLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/GridLoader-tests.tsx.snap
@@ -41,7 +41,7 @@ exports[`GridLoader should match snapshot 1`] = `
   animation: animation-0 1.1s 0.3s infinite ease;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -49,45 +49,36 @@ exports[`GridLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-9"
   >
     <div
-      className="emotion-9"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-0"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-0"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/HashLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/HashLoader-tests.tsx.snap
@@ -88,30 +88,22 @@ exports[`HashLoader should match snapshot 1`] = `
   animation: animation-1 2s infinite;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={50}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={50}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
@@ -49,30 +49,22 @@ exports[`MoonLoader should match snapshot 1`] = `
   opacity: 0.1;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={60}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={60}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
@@ -186,7 +186,7 @@ exports[`PacmanLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -194,36 +194,27 @@ exports[`PacmanLoader should match snapshot 1`] = `
   size={25}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={25}
-    sizeUnit="px"
+  <div
+    className="emotion-6"
   >
     <div
-      className="emotion-6"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-      <div
-        className="emotion-3"
-      />
-      <div
-        className="emotion-4"
-      />
-      <div
-        className="emotion-5"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+    <div
+      className="emotion-3"
+    />
+    <div
+      className="emotion-4"
+    />
+    <div
+      className="emotion-5"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
@@ -227,42 +227,34 @@ exports[`PropagateLoader should match snapshot 1`] = `
   animation-fill-mode: forwards;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-6"
   >
     <div
-      className="emotion-6"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-      <div
-        className="emotion-3"
-      />
-      <div
-        className="emotion-4"
-      />
-      <div
-        className="emotion-5"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+    <div
+      className="emotion-3"
+    />
+    <div
+      className="emotion-4"
+    />
+    <div
+      className="emotion-5"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/PulseLoader-test.tsx.snap
+++ b/__tests__/__snapshots__/PulseLoader-test.tsx.snap
@@ -109,7 +109,7 @@ exports[`PulseLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -117,27 +117,18 @@ exports[`PulseLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-3"
   >
     <div
-      className="emotion-3"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/RingLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RingLoader-tests.tsx.snap
@@ -73,30 +73,22 @@ exports[`RingLoader should match snapshot 1`] = `
   animation: animation-1 2s 0s infinite linear;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={60}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={60}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
@@ -91,7 +91,7 @@ exports[`RiseLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -99,33 +99,24 @@ exports[`RiseLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-5"
   >
     <div
-      className="emotion-5"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-0"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-0"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
@@ -59,7 +59,7 @@ exports[`RotateLoader should match snapshot 1`] = `
   left: 25px;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -67,24 +67,15 @@ exports[`RotateLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-2"
   >
     <div
-      className="emotion-2"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
@@ -166,7 +166,7 @@ exports[`ScaleLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   height={35}
@@ -178,37 +178,24 @@ exports[`ScaleLoader should match snapshot 1`] = `
   width={4}
   widthUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    height={35}
-    heightUnit="px"
-    loading={true}
-    margin="2px"
-    radius={2}
-    radiusUnit="px"
-    width={4}
-    widthUnit="px"
+  <div
+    className="emotion-5"
   >
     <div
-      className="emotion-5"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-      <div
-        className="emotion-3"
-      />
-      <div
-        className="emotion-4"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+    <div
+      className="emotion-3"
+    />
+    <div
+      className="emotion-4"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
@@ -40,23 +40,15 @@ exports[`SkewLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={20}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={20}
-    sizeUnit="px"
-  >
-    <div
-      className="emotion-0"
-    />
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+  <div
+    className="emotion-0"
+  />
+</Loader>
 `;

--- a/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
@@ -38,23 +38,15 @@ exports[`SquareLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
   size={50}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    size={50}
-    sizeUnit="px"
-  >
-    <div
-      className="emotion-0"
-    />
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+  <div
+    className="emotion-0"
+  />
+</Loader>
 `;

--- a/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
@@ -100,7 +100,7 @@ exports[`SyncLoader should match snapshot 1`] = `
   animation-fill-mode: both;
 }
 
-<onlyUpdateForKeys(Loader)
+<Loader
   color="#000000"
   css={Object {}}
   loading={true}
@@ -108,27 +108,18 @@ exports[`SyncLoader should match snapshot 1`] = `
   size={15}
   sizeUnit="px"
 >
-  <Loader
-    color="#000000"
-    css={Object {}}
-    loading={true}
-    margin="2px"
-    size={15}
-    sizeUnit="px"
+  <div
+    className="emotion-3"
   >
     <div
-      className="emotion-3"
-    >
-      <div
-        className="emotion-0"
-      />
-      <div
-        className="emotion-1"
-      />
-      <div
-        className="emotion-2"
-      />
-    </div>
-  </Loader>
-</onlyUpdateForKeys(Loader)>
+      className="emotion-0"
+    />
+    <div
+      className="emotion-1"
+    />
+    <div
+      className="emotion-2"
+    />
+  </div>
+</Loader>
 `;

--- a/__tests__/helpers/proptypes-tests.ts
+++ b/__tests__/helpers/proptypes-tests.ts
@@ -1,96 +1,10 @@
 import {
-  sizeKeys,
-  sizeMarginKeys,
-  heightWidthKeys,
-  heightWidthRadiusKeys,
   sizeDefaults,
   DefaultProps,
   sizeMarginDefaults,
   heightWidthDefaults,
   heightWidthRadiusDefaults
 } from "../../src/helpers";
-
-describe("Arrays for onlyUpdateForKeys function", () => {
-  describe("sizeKeys", () => {
-    it("should be an array of length 5", () => {
-      expect(Array.isArray(sizeKeys)).toBe(true);
-      expect(sizeKeys).toHaveLength(5);
-    });
-
-    it("should contain the common props: loading, color, css", () => {
-      expect(sizeKeys).toContain("loading");
-      expect(sizeKeys).toContain("color");
-      expect(sizeKeys).toContain("css");
-    });
-
-    it("should contain size and size unit keys", () => {
-      expect(sizeKeys).toContain("size");
-      expect(sizeKeys).toContain("sizeUnit");
-    });
-  });
-
-  describe("sizeMarginKeys", () => {
-    it("should be an array of length 6", () => {
-      expect(Array.isArray(sizeMarginKeys)).toBe(true);
-      expect(sizeMarginKeys).toHaveLength(6);
-    });
-
-    it("should contain the common props: loading, color, css", () => {
-      expect(sizeMarginKeys).toContain("loading");
-      expect(sizeMarginKeys).toContain("color");
-      expect(sizeMarginKeys).toContain("css");
-    });
-
-    it("should contain size and size unit keys", () => {
-      expect(sizeMarginKeys).toContain("size");
-      expect(sizeMarginKeys).toContain("sizeUnit");
-      expect(sizeMarginKeys).toContain("margin");
-    });
-  });
-
-  describe("heightWidthKeys", () => {
-    it("should be an array of length 7", () => {
-      expect(Array.isArray(heightWidthKeys)).toBe(true);
-      expect(heightWidthKeys).toHaveLength(7);
-    });
-
-    it("should contain the common props: loading, color, css", () => {
-      expect(heightWidthKeys).toContain("loading");
-      expect(heightWidthKeys).toContain("color");
-      expect(heightWidthKeys).toContain("css");
-    });
-
-    it("should contain size and size unit keys", () => {
-      expect(heightWidthKeys).toContain("height");
-      expect(heightWidthKeys).toContain("heightUnit");
-      expect(heightWidthKeys).toContain("width");
-      expect(heightWidthKeys).toContain("widthUnit");
-    });
-  });
-
-  describe("heightWidthRadiusKeys", () => {
-    it("should be an array of length 7", () => {
-      expect(Array.isArray(heightWidthRadiusKeys)).toBe(true);
-      expect(heightWidthRadiusKeys).toHaveLength(10);
-    });
-
-    it("should contain the common props: loading, color, css", () => {
-      expect(heightWidthRadiusKeys).toContain("loading");
-      expect(heightWidthRadiusKeys).toContain("color");
-      expect(heightWidthRadiusKeys).toContain("css");
-    });
-
-    it("should contain size and size unit keys", () => {
-      expect(heightWidthRadiusKeys).toContain("height");
-      expect(heightWidthRadiusKeys).toContain("heightUnit");
-      expect(heightWidthRadiusKeys).toContain("width");
-      expect(heightWidthRadiusKeys).toContain("widthUnit");
-      expect(heightWidthRadiusKeys).toContain("radius");
-      expect(heightWidthRadiusKeys).toContain("radiusUnit");
-      expect(heightWidthRadiusKeys).toContain("margin");
-    });
-  });
-});
 
 describe("Default Props functions for different loaders", () => {
   describe("sizeDefaults", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinners",
-  "version": "0.6.0-alpha.0",
+  "version": "0.6.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2202,21 +2202,6 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-      "requires": {
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -2877,12 +2862,14 @@
     "@types/prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "dev": true
     },
     "@types/react": {
       "version": "16.8.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
       "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -2911,14 +2898,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
       "integrity": "sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==",
       "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/recompose": {
-      "version": "0.30.6",
-      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.30.6.tgz",
-      "integrity": "sha512-A9c880h07JMrvVe+PwyjVihrQRyKWp4/GFjfA9YE4NgxdEuQD74gSdDhInhUNctO/dkCcR66rexEXevzBy85cQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -3334,7 +3313,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -4137,11 +4117,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -4931,6 +4906,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -5442,6 +5418,7 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
       "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -5455,7 +5432,8 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         }
       }
     },
@@ -6547,7 +6525,8 @@
     "hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -6690,7 +6669,8 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
@@ -6935,7 +6915,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -6998,6 +6979,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -8331,7 +8313,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -8574,6 +8557,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -9000,6 +8984,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
       "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -9135,7 +9120,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9667,6 +9653,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -9920,11 +9907,6 @@
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
       "dev": true
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-test-renderer": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
@@ -10032,19 +10014,6 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
       }
     },
     "reflect.ownkeys": {
@@ -10454,7 +10423,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -10938,11 +10908,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -11501,7 +11466,8 @@
     "ua-parser-js": {
       "version": "0.7.14",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",
@@ -11973,7 +11939,8 @@
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,6 @@
     "react-dom": "^16.0.0"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.4",
-    "@types/recompose": "^0.30.6",
-    "recompose": "0.27.1 - 0.30.0"
+    "@emotion/core": "^10.0.4"
   }
 }

--- a/src/BarLoader.tsx
+++ b/src/BarLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { calculateRgba, heightWidthDefaults, heightWidthKeys } from "./helpers";
+import { calculateRgba, heightWidthDefaults } from "./helpers";
 import {
   LoaderHeightWidthProps,
   StyleFunction,
@@ -73,8 +72,4 @@ export class Loader extends React.PureComponent<LoaderHeightWidthProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderHeightWidthProps> = onlyUpdateForKeys(heightWidthKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/BeatLoader.tsx
+++ b/src/BeatLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginKeys, sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import { LoaderSizeMarginProps, PrecompiledCss, StyleFunctionWithIndex } from "./interfaces";
 
 const beat: Keyframes = keyframes`
@@ -42,8 +41,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -59,6 +58,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/CircleLoader.tsx
+++ b/src/CircleLoader.tsx
@@ -1,9 +1,8 @@
 /** @jsx jsx */
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import { Keyframes } from "@emotion/serialize";
 import {
   StyleFunction,
@@ -65,6 +64,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/ClimbingBoxLoader.tsx
+++ b/src/ClimbingBoxLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const climbingBox: Keyframes = keyframes`
@@ -93,6 +92,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/ClipLoader.tsx
+++ b/src/ClipLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers/proptypes";
+import { sizeDefaults } from "./helpers/proptypes";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const clip: Keyframes = keyframes`
@@ -40,6 +39,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/DotLoader.tsx
+++ b/src/DotLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -64,6 +63,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/FadeLoader.tsx
+++ b/src/FadeLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { heightWidthRadiusKeys, heightWidthRadiusDefaults } from "./helpers";
+import { heightWidthRadiusDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,

--- a/src/FadeLoader.tsx
+++ b/src/FadeLoader.tsx
@@ -2,7 +2,6 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
 import { heightWidthRadiusKeys, heightWidthRadiusDefaults } from "./helpers";
 import {
@@ -114,8 +113,4 @@ class Loader extends React.PureComponent<LoaderHeightWidthRadiusProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderHeightWidthRadiusProps> = onlyUpdateForKeys(
-  heightWidthRadiusKeys
-)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -75,8 +74,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/HashLoader.tsx
+++ b/src/HashLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { calculateRgba, sizeDefaults, sizeKeys } from "./helpers/index";
+import { calculateRgba, sizeDefaults } from "./helpers/index";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -109,6 +108,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/MoonLoader.tsx
+++ b/src/MoonLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps, CalcFunction } from "./interfaces";
 
 type BallStyleFunction = (size: number) => PrecompiledCss;
@@ -80,6 +79,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/PacmanLoader.tsx
+++ b/src/PacmanLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -116,8 +115,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/PropagateLoader.tsx
+++ b/src/PropagateLoader.tsx
@@ -2,7 +2,6 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
 import { sizeDefaults, sizeKeys } from "./helpers";
 import {
@@ -92,6 +91,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/PropagateLoader.tsx
+++ b/src/PropagateLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,

--- a/src/PulseLoader.tsx
+++ b/src/PulseLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
 
 const pulse: Keyframes = keyframes`
@@ -44,8 +43,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/RingLoader.tsx
+++ b/src/RingLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -65,6 +64,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/RiseLoader.tsx
+++ b/src/RiseLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
 
 const riseAmount: number = 30;
@@ -58,8 +57,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/RotateLoader.tsx
+++ b/src/RotateLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers";
+import { sizeMarginDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -71,8 +70,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/ScaleLoader.tsx
+++ b/src/ScaleLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { heightWidthRadiusDefaults, heightWidthRadiusKeys } from "./helpers";
+import { heightWidthRadiusDefaults } from "./helpers";
 import { PrecompiledCss, LoaderHeightWidthRadiusProps, StyleFunctionWithIndex } from "./interfaces";
 
 const scale: Keyframes = keyframes`
@@ -46,8 +45,4 @@ class Loader extends React.PureComponent<LoaderHeightWidthRadiusProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderHeightWidthRadiusProps> = onlyUpdateForKeys(
-  heightWidthRadiusKeys
-)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/SkewLoader.tsx
+++ b/src/SkewLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeDefaults, sizeKeys } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const skew: Keyframes = keyframes`
@@ -39,6 +38,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/SquareLoader.tsx
+++ b/src/SquareLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeKeys, sizeDefaults } from "./helpers";
+import { sizeDefaults } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const square: Keyframes = keyframes`
@@ -37,6 +36,4 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeProps> = onlyUpdateForKeys(sizeKeys)(Loader);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/SyncLoader.tsx
+++ b/src/SyncLoader.tsx
@@ -2,9 +2,8 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
-import onlyUpdateForKeys from "recompose/onlyUpdateForKeys";
 
-import { sizeMarginDefaults, sizeMarginKeys } from "./helpers/proptypes";
+import { sizeMarginDefaults } from "./helpers/proptypes";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
 
 const sync: Keyframes = keyframes`
@@ -44,8 +43,4 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   }
 }
 
-const Component: React.ComponentClass<LoaderSizeMarginProps> = onlyUpdateForKeys(sizeMarginKeys)(
-  Loader
-);
-Component.defaultProps = Loader.defaultProps;
-export default Component;
+export default Loader;

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -15,22 +15,6 @@ const RADIUS_UNIT: string = "radiusUnit";
 const MARGIN: string = "margin";
 
 /*
- * Array for onlyUpdateForKeys function
- */
-const commonStrings: string[] = [LOADING, COLOR, CSS];
-const sizeStrings: string[] = [SIZE, SIZE_UNIT];
-const heightWidthString: string[] = [HEIGHT, HEIGHT_UNIT, WIDTH, WIDTH_UNIT];
-
-export const sizeKeys: string[] = commonStrings.concat(sizeStrings);
-export const sizeMarginKeys: string[] = sizeKeys.concat([MARGIN]);
-export const heightWidthKeys: string[] = commonStrings.concat(heightWidthString);
-export const heightWidthRadiusKeys: string[] = heightWidthKeys.concat([
-  RADIUS,
-  RADIUS_UNIT,
-  MARGIN
-]);
-
-/*
  * DefaultProps object for different loaders
  */
 


### PR DESCRIPTION
We want the loader to update for all the props. So there was no need to keep `recompose` as a dependency. 