### PR TITLE
Prepping for v0.6.0 release (TypeScript rewrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. This projec
 - Major changes: 
     - Add support for types for individual loader imports
     - Add support for using basic color name as props instead of only color hashes
-    - Reduced package size from around 850kb to 135gb
+    - Reduced total package size from around 850kb to 135gb
     - Fix `main` key value in `package.json` to point to the correct `index.js`
     - Removed `prop-types` and `recompose` from dependencies
     - Added tests to get to 100% code coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.6.0
+
+- Offical release for the TypeScript rewrite! 
+- Major changes: 
+    - Add support for types for individual loader imports
+    - Add support for using basic color name as props instead of only color hashes
+    - Reduced package size from around 850kb to 135gb
+    - Fix `main` key value in `package.json` to point to the correct `index.js`
+    - Removed `prop-types` and `recompose` from dependencies
+    - Added tests to get to 100% code coverage
+
 ## 0.6.0-beta.1
 
 - updated `devDependencies` to latest versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinners",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0",
   "description": "A collection of react loading spinners",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- updated changelog for `0.6.0`
- bump `package.json` version

