### PR TITLE
[Unit Prop Removal] add unit converter function and tests

### DIFF
--- a/__tests__/helpers/unitConverter-tests.ts
+++ b/__tests__/helpers/unitConverter-tests.ts
@@ -7,6 +7,7 @@ describe("unitConverter", () => {
     value: 12,
     unit: "px"
   };
+
   it("is a function", () => {
     expect(typeof unitConverter).toEqual("function");
   });

--- a/__tests__/helpers/unitConverter-tests.ts
+++ b/__tests__/helpers/unitConverter-tests.ts
@@ -1,0 +1,37 @@
+import { unitConverter } from "../../src/helpers";
+import { LengthObject } from "../../src/interfaces";
+
+describe("unitConverter", () => {
+  let spy: jest.SpyInstance = jest.spyOn(console, "warn");
+  let output: LengthObject = {
+    value: 12,
+    unit: "px"
+  };
+  it("is a function", () => {
+    expect(typeof unitConverter).toEqual("function");
+  });
+
+  it("takes a number as the input and append px to the value", () => {
+    expect(unitConverter(12)).toEqual(output);
+    expect(spy).not.toBeCalled();
+  });
+
+  it("take a string with valid integer css unit and return an object with value and unit", () => {
+    expect(unitConverter("12px")).toEqual(output);
+    expect(spy).not.toBeCalled();
+  });
+
+  it("take a string with valid css float unit and return an object with value and unit", () => {
+    let output: LengthObject = {
+      value: 12.5,
+      unit: "px"
+    };
+    expect(unitConverter("12.5px")).toEqual(output);
+    expect(spy).not.toBeCalled();
+  });
+
+  it("takes an invalid css unit and default the value to px", () => {
+    expect(unitConverter("12fd")).toEqual(output);
+    expect(spy).toBeCalled();
+  });
+});

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from "./proptypes";
 export * from "./colors";
+export * from "./unitConverter";

--- a/src/helpers/unitConverter.ts
+++ b/src/helpers/unitConverter.ts
@@ -1,0 +1,60 @@
+import { LengthObject } from "../interfaces";
+
+const cssUnit: { [unit: string]: boolean } = {
+  cm: true,
+  mm: true,
+  in: true,
+  px: true,
+  pt: true,
+  pc: true,
+  em: true,
+  ex: true,
+  ch: true,
+  rem: true,
+  vw: true,
+  vh: true,
+  vmin: true,
+  vmax: true,
+  "%": true
+};
+
+/**
+ * If size is a number, append px to the value as default unit.
+ * If size is a string, validate against list of valid units.
+ * If unit is valid, return size as is.
+ * If unit is invalid, console warn issue, replace with px as the unit.
+ *
+ * @param {(number | string)} size
+ * @return {LengthObject} LengthObject
+ */
+export function unitConverter(size: number | string): LengthObject {
+  if (typeof size === "number") {
+    return {
+      value: size,
+      unit: "px"
+    };
+  }
+  let value: number;
+  let valueString: string = size.match(/^[0-9.]*/)!.toString();
+  if (valueString.includes(".")) {
+    value = parseFloat(valueString);
+  } else {
+    value = parseInt(valueString, 10);
+  }
+
+  let unit: string = size.match(/[^0-9]*$/)!.toString();
+
+  if (cssUnit[unit]) {
+    return {
+      value,
+      unit
+    };
+  }
+
+  console.warn(`React Spinners: ${size} is not a valid css value. Defaulting to ${value}px.`);
+
+  return {
+    value,
+    unit: "px"
+  };
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,11 @@ export interface PrecompiledCss {
   styles: string;
 }
 
+export interface LengthObject {
+  value: number;
+  unit: string;
+}
+
 export type StyleFunction = () => PrecompiledCss;
 
 export type StyleFunctionWithIndex = (i: number) => PrecompiledCss;
@@ -23,9 +28,10 @@ export interface LoaderHeightWidthProps extends CommonProps {
 }
 
 export interface LoaderSizeProps extends CommonProps {
-  size?: number;
-  sizeUnit?: string;
+  size?: number | string;
 }
+
+export type LoaderSizeDefaultProps = Required<LoaderSizeProps>;
 
 export interface LoaderSizeMarginProps extends LoaderSizeProps {
   margin?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,10 +28,9 @@ export interface LoaderHeightWidthProps extends CommonProps {
 }
 
 export interface LoaderSizeProps extends CommonProps {
-  size?: number | string;
+  size?: number;
+  sizeUnit?: string;
 }
-
-export type LoaderSizeDefaultProps = Required<LoaderSizeProps>;
 
 export interface LoaderSizeMarginProps extends LoaderSizeProps {
   margin?: string;


### PR DESCRIPTION
Adding a function to convert the size prop to the appropriate string. 

if number => number+px
if string => validate unit, if valid, return as is, else default to px with console warning