### PR TITLE
add secondary color to PacmanLoader

### DIFF
--- a/examples/components/Form.tsx
+++ b/examples/components/Form.tsx
@@ -15,7 +15,7 @@ const Form: FormType = ({ inputs, update }: FormProps): JSX.Element => (
       <div className="spinner-form-input" key={name}>
         <input
           name={name}
-          type={name === "margin" ? "text" : "number"}
+          type={["margin", "color2"].indexOf(name) !== -1 ? "text" : "number"}
           value={inputs[name]}
           onChange={update(name)}
         />

--- a/src/PacmanLoader.tsx
+++ b/src/PacmanLoader.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginSecondaryColorDefaults } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
-  LoaderSizeMarginProps,
+  LoaderSizeMarginSecondaryColorProps,
   CalcFunction,
   StyleFunctionWithIndex
 } from "./interfaces";
@@ -23,8 +23,11 @@ const pacman: Keyframes[] = [
   `
 ];
 
-class Loader extends React.PureComponent<LoaderSizeMarginProps> {
-  public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(25);
+class Loader extends React.PureComponent<LoaderSizeMarginSecondaryColorProps> {
+  public static defaultProps: LoaderSizeMarginSecondaryColorProps = sizeMarginSecondaryColorDefaults(
+    25,
+    ""
+  );
 
   public ball: CalcFunction<Keyframes> = (): Keyframes => {
     const { size, sizeUnit } = this.props;
@@ -36,12 +39,16 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   };
 
   public ballStyle: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, margin, size, sizeUnit } = this.props;
+    console.debug(this.props);
+    const { color, color2, margin, size, sizeUnit } = this.props;
+    let c: string = color;
+
+    if (color2 !== undefined && color2.length !== 0) c = color2;
 
     return css`
       width: ${`${size! / 3}${sizeUnit}`};
       height: ${`${size! / 3}${sizeUnit}`};
-      background-color: ${color};
+      background-color: ${c};
       margin: ${margin};
       border-radius: 100%;
       transform: translate(0, ${`${-size! / 4}${sizeUnit}`});
@@ -82,6 +89,7 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
       position: absolute;
       animation: ${pacman[i]} 0.8s infinite ease-in-out;
       animation-fill-mode: both;
+      z-index: 1;
     `;
   };
 

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -3,6 +3,7 @@
  */
 const LOADING: string = "loading";
 const COLOR: string = "color";
+const COLOR2: string = "color2";
 const CSS: string = "css";
 const SIZE: string = "size";
 const SIZE_UNIT: string = "sizeUnit";
@@ -25,6 +26,7 @@ export interface DefaultProps {
 type HeightWidthFunction = (height: number, width: number) => DefaultProps;
 type HeightWidthRadiusFunction = (height: number, width: number, radius?: number) => DefaultProps;
 type SizeFunction = (size: number) => DefaultProps;
+type SizeSecondaryColorFunction = (size: number, color2: string) => DefaultProps;
 
 const commonValues: DefaultProps = {
   [LOADING]: true,
@@ -51,6 +53,16 @@ export const sizeDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
 export const sizeMarginDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
   return Object.assign({}, sizeDefaults(sizeValue), {
     [MARGIN]: "2px"
+  });
+};
+
+export const sizeMarginSecondaryColorDefaults: SizeSecondaryColorFunction = (
+  sizeValue: number,
+  color2: string
+): DefaultProps => {
+  return Object.assign({}, sizeDefaults(sizeValue), {
+    [MARGIN]: "2px",
+    [COLOR2]: color2
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ import {
   LoaderHeightWidthProps,
   LoaderSizeMarginProps,
   LoaderSizeProps,
-  LoaderHeightWidthRadiusProps
+  LoaderHeightWidthRadiusProps,
+  LoaderSizeMarginSecondaryColorProps
 } from "./interfaces";
 
 export const BarLoader: React.ComponentClass<LoaderHeightWidthProps> = BarLoaderComponent;
@@ -38,7 +39,7 @@ export const FadeLoader: React.ComponentClass<LoaderHeightWidthRadiusProps> = Fa
 export const GridLoader: React.ComponentClass<LoaderSizeMarginProps> = GridLoaderComponent;
 export const HashLoader: React.ComponentClass<LoaderSizeProps> = HashLoaderComponent;
 export const MoonLoader: React.ComponentClass<LoaderSizeProps> = MoonLoaderComponent;
-export const PacmanLoader: React.ComponentClass<LoaderSizeMarginProps> = PacmanLoaderComponent;
+export const PacmanLoader: React.ComponentClass<LoaderSizeMarginSecondaryColorProps> = PacmanLoaderComponent;
 export const PropagateLoader: React.ComponentClass<LoaderSizeProps> = PropagateLoaderComponent;
 export const PulseLoader: React.ComponentClass<LoaderSizeMarginProps> = PulseLoaderComponent;
 export const RingLoader: React.ComponentClass<LoaderSizeProps> = RingLoaderComponent;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,3 +41,7 @@ export interface LoaderHeightWidthRadiusProps extends LoaderHeightWidthProps {
   radius?: number;
   radiusUnit?: string;
 }
+
+export interface LoaderSizeMarginSecondaryColorProps extends LoaderSizeMarginProps {
+  color2?: string;
+}


### PR DESCRIPTION
add secondary color for the Pacman-Balls.
If `color2` is not set fallback to `color`

```javascript
import { PacmanLoader } from 'react-spinners';
...
<PacmanLoader color={'#FFFF00'} color2={'#FD0000'} />
...
```