### PR TITLE
unit props deprecation: update proptypes and interfaces + bounceloader

### DIFF
--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -77,7 +77,7 @@ describe("BarLoader", () => {
       let height: string = `${length}${unit}`;
       loader = mount(<BarLoader height={height} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-      expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
       expect(loader.find("div div")).not.toHaveStyleRule(
         "height",
         `${defaultHeight}${defaultUnit}`

--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -46,36 +46,69 @@ describe("BarLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", color);
   });
 
-  it("should render the correct height based on props", () => {
-    let height: number = 10;
-    loader = mount(<BarLoader height={height} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+  describe("height prop", () => {
+    it("should render the height with px unit when size is a number", () => {
+      let height: number = 10;
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+    });
+
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let height: string = "18%";
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${height}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}`);
+    });
+
+    it("should render the height with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let height: string = `${length}${unit}`;
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct heightUnit basd on passed in props", () => {
-    let unit: string = "%";
-    loader = mount(<BarLoader heightUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultHeight}${unit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultHeight}${unit}`);
-  });
+  describe("width prop", () => {
+    it("should render the width with px unit when size is a number", () => {
+      let width: number = 10;
+      loader = mount(<BarLoader width={10} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${width}${defaultUnit}`);
+    });
 
-  it("should render the correct width based on props", () => {
-    let width: number = 10;
-    loader = mount(<BarLoader width={10} />);
-    expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${width}${defaultUnit}`);
-  });
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let width: string = "18%";
+      loader = mount(<BarLoader width={width} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${width}`);
+    });
 
-  it("should render the correct widthUnit basd on passed in props", () => {
-    let unit: string = "%";
-    loader = mount(<BarLoader widthUnit="%" />);
-    expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultWidth}${unit}`);
+    it("should render the width with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let width: string = `${length}${unit}`;
+      loader = mount(<BarLoader width={width} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/BeatLoader-tests.tsx
+++ b/__tests__/BeatLoader-tests.tsx
@@ -12,6 +12,7 @@ describe("BeatLoader", () => {
   let props: LoaderSizeMarginProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultUnit: string = "px";
 
   it("should match snapshot", () => {
@@ -43,28 +44,69 @@ describe("BeatLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", "#e2e2e2");
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<BeatLoader size={18} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<BeatLoader size={18} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct heightUnit basd on props", () => {
-    let unit: string = "%";
-    loader = mount(<BeatLoader sizeUnit="%" />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${unit}`);
-  });
+  describe("margin prop", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<BeatLoader margin={18} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+    });
 
-  it("should render the correct margin props based on props", () => {
-    loader = mount(<BeatLoader margin="4%" />);
-    expect(loader.find("div div")).not.toHaveStyleRule("margin", "2px");
-    expect(loader.find("div div")).toHaveStyleRule("margin", "4%");
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<BeatLoader margin={margin} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${margin}`);
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<BeatLoader margin={margin} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/BounceLoader-tests.tsx
+++ b/__tests__/BounceLoader-tests.tsx
@@ -62,8 +62,8 @@ describe("BounceLoader", () => {
     it("should render the size as is when size is a string with valid css unit", () => {
       let size: string = "18px";
       loader = mount(<BounceLoader size={size} />);
-      expect(loader).not.toHaveStyleRule("height", `${defaultSize}`);
-      expect(loader).not.toHaveStyleRule("width", `${defaultSize}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
       expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
@@ -78,8 +78,8 @@ describe("BounceLoader", () => {
       let unit: string = "ad";
       let size: string = `${length}${unit}`;
       loader = mount(<BounceLoader size={size} />);
-      expect(loader).not.toHaveStyleRule("height", `${defaultSize}`);
-      expect(loader).not.toHaveStyleRule("width", `${defaultSize}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
       expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 

--- a/__tests__/BounceLoader-tests.tsx
+++ b/__tests__/BounceLoader-tests.tsx
@@ -44,27 +44,50 @@ describe("BounceLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", color);
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<BounceLoader size={size} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-    expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
-  });
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<BounceLoader sizeUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${unit}`);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/__snapshots__/BarLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BarLoader-tests.tsx.snap
@@ -76,12 +76,10 @@ exports[`BarLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   height={4}
-  heightUnit="px"
   loading={true}
   width={100}
-  widthUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
@@ -61,11 +61,10 @@ exports[`BeatLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   margin="2px"
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-3"

--- a/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
@@ -67,10 +67,9 @@ exports[`BounceLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={60}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/helpers/proptypes-tests.ts
+++ b/__tests__/helpers/proptypes-tests.ts
@@ -1,10 +1,15 @@
 import {
   sizeDefaults,
-  DefaultProps,
   sizeMarginDefaults,
   heightWidthDefaults,
   heightWidthRadiusDefaults
 } from "../../src/helpers";
+import {
+  LoaderSizeProps,
+  LoaderSizeMarginProps,
+  LoaderHeightWidthRadiusProps,
+  LoaderHeightWidthProps
+} from "../../src/interfaces";
 
 describe("Default Props functions for different loaders", () => {
   describe("sizeDefaults", () => {
@@ -13,23 +18,21 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = sizeDefaults(1);
+      let defaultProps: Required<LoaderSizeProps> = sizeDefaults(1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the size as the passed in size value", () => {
-      let defaultProps1: DefaultProps = sizeDefaults(1);
+      let defaultProps1: Required<LoaderSizeProps> = sizeDefaults(1);
       expect(defaultProps1).toHaveProperty("size");
       expect(defaultProps1.size).toEqual(1);
-      expect(defaultProps1).toHaveProperty("sizeUnit");
-      expect(defaultProps1.sizeUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = sizeDefaults(2);
+      let defaultProps2: Required<LoaderSizeProps> = sizeDefaults(2);
       expect(defaultProps2).toHaveProperty("size");
       expect(defaultProps2.size).toEqual(2);
     });
@@ -41,25 +44,23 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = sizeMarginDefaults(1);
+      let defaultProps: Required<LoaderSizeMarginProps> = sizeMarginDefaults(1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the size as the passed in size value", () => {
-      let defaultProps1: DefaultProps = sizeMarginDefaults(1);
+      let defaultProps1: Required<LoaderSizeMarginProps> = sizeMarginDefaults(1);
       expect(defaultProps1).toHaveProperty("size");
       expect(defaultProps1.size).toEqual(1);
-      expect(defaultProps1).toHaveProperty("sizeUnit");
-      expect(defaultProps1.sizeUnit).toEqual("px");
       expect(defaultProps1).toHaveProperty("margin");
       expect(defaultProps1.margin).toEqual("2px");
 
-      let defaultProps2: DefaultProps = sizeMarginDefaults(2);
+      let defaultProps2: Required<LoaderSizeMarginProps> = sizeMarginDefaults(2);
       expect(defaultProps2).toHaveProperty("size");
       expect(defaultProps2.size).toEqual(2);
     });
@@ -71,27 +72,23 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = heightWidthDefaults(1, 1);
+      let defaultProps: Required<LoaderHeightWidthProps> = heightWidthDefaults(1, 1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the height/width as the passed in height/width value", () => {
-      let defaultProps1: DefaultProps = heightWidthDefaults(1, 2);
+      let defaultProps1: Required<LoaderHeightWidthProps> = heightWidthDefaults(1, 2);
       expect(defaultProps1).toHaveProperty("height");
       expect(defaultProps1.height).toEqual(1);
       expect(defaultProps1).toHaveProperty("width");
       expect(defaultProps1.width).toEqual(2);
-      expect(defaultProps1).toHaveProperty("heightUnit");
-      expect(defaultProps1.heightUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("widthUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = heightWidthDefaults(3, 4);
+      let defaultProps2: Required<LoaderHeightWidthProps> = heightWidthDefaults(3, 4);
       expect(defaultProps2).toHaveProperty("height");
       expect(defaultProps2.height).toEqual(3);
       expect(defaultProps2).toHaveProperty("width");
@@ -105,31 +102,33 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = heightWidthRadiusDefaults(1, 1, 1);
+      let defaultProps: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(1, 1, 1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the height/width as the passed in height/width value", () => {
-      let defaultProps1: DefaultProps = heightWidthRadiusDefaults(1, 2, 3);
+      let defaultProps1: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(
+        1,
+        2,
+        3
+      );
       expect(defaultProps1).toHaveProperty("height");
       expect(defaultProps1.height).toEqual(1);
       expect(defaultProps1).toHaveProperty("width");
       expect(defaultProps1.width).toEqual(2);
       expect(defaultProps1).toHaveProperty("radius");
       expect(defaultProps1.radius).toEqual(3);
-      expect(defaultProps1).toHaveProperty("heightUnit");
-      expect(defaultProps1.heightUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("widthUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("radiusUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = heightWidthRadiusDefaults(4, 5, 6);
+      let defaultProps2: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(
+        4,
+        5,
+        6
+      );
       expect(defaultProps2).toHaveProperty("height");
       expect(defaultProps2.height).toEqual(4);
       expect(defaultProps2).toHaveProperty("width");
@@ -139,7 +138,7 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("radius value should default to 2", () => {
-      let defaultProps: DefaultProps = heightWidthRadiusDefaults(5, 6);
+      let defaultProps: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(5, 6);
       expect(defaultProps.radius).toEqual(2);
     });
   });

--- a/__tests__/helpers/unitConverter-tests.ts
+++ b/__tests__/helpers/unitConverter-tests.ts
@@ -1,38 +1,59 @@
-import { unitConverter } from "../../src/helpers";
+import { parseLengthAndUnit, cssValue } from "../../src/helpers";
 import { LengthObject } from "../../src/interfaces";
 
 describe("unitConverter", () => {
-  let spy: jest.SpyInstance = jest.spyOn(console, "warn");
-  let output: LengthObject = {
-    value: 12,
-    unit: "px"
-  };
-
-  it("is a function", () => {
-    expect(typeof unitConverter).toEqual("function");
-  });
-
-  it("takes a number as the input and append px to the value", () => {
-    expect(unitConverter(12)).toEqual(output);
-    expect(spy).not.toBeCalled();
-  });
-
-  it("take a string with valid integer css unit and return an object with value and unit", () => {
-    expect(unitConverter("12px")).toEqual(output);
-    expect(spy).not.toBeCalled();
-  });
-
-  it("take a string with valid css float unit and return an object with value and unit", () => {
+  describe("parseLengthAndUnit", () => {
+    let spy: jest.SpyInstance = jest.spyOn(console, "warn");
     let output: LengthObject = {
-      value: 12.5,
+      value: 12,
       unit: "px"
     };
-    expect(unitConverter("12.5px")).toEqual(output);
-    expect(spy).not.toBeCalled();
+
+    it("is a function", () => {
+      expect(typeof parseLengthAndUnit).toEqual("function");
+    });
+
+    it("takes a number as the input and append px to the value", () => {
+      expect(parseLengthAndUnit(12)).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("take a string with valid integer css unit and return an object with value and unit", () => {
+      expect(parseLengthAndUnit("12px")).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("take a string with valid css float unit and return an object with value and unit", () => {
+      let output: LengthObject = {
+        value: 12.5,
+        unit: "px"
+      };
+      expect(parseLengthAndUnit("12.5px")).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("takes an invalid css unit and default the value to px", () => {
+      expect(parseLengthAndUnit("12fd")).toEqual(output);
+      expect(spy).toBeCalled();
+    });
   });
 
-  it("takes an invalid css unit and default the value to px", () => {
-    expect(unitConverter("12fd")).toEqual(output);
-    expect(spy).toBeCalled();
+  describe("cssValue", () => {
+    it("is a function", () => {
+      expect(typeof cssValue).toEqual("function");
+    });
+
+    it("takes a number as the input and append px to the value", () => {
+      expect(cssValue(12)).toEqual("12px");
+    });
+
+    it("takes a string with valid css unit as the input and return the value", () => {
+      expect(cssValue("12%")).toEqual("12%");
+      expect(cssValue("12em")).toEqual("12em");
+    });
+
+    it("takes a string with invalid css unit as the input and default to px", () => {
+      expect(cssValue("12qw")).toEqual("12px");
+    });
   });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
     ga('send', 'pageview');
 
   </script>
-<script type="text/javascript" src="vendors~main-e50b6df8ee587f0399c5.js"></script><script type="text/javascript" src="main-e50b6df8ee587f0399c5.js"></script></head>
+<script type="text/javascript" src="js/vendors~main-110e84b40e5352118e45.js"></script><script type="text/javascript" src="js/main-110e84b40e5352118e45.js"></script></head>
 
 <body>
   <header id='header'>

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -6,6 +6,7 @@ import { ColorResult } from "react-color";
 
 import { Code, ColorPicker, LoaderItem } from "./components";
 import * as Spinners from "../src";
+import BounceLoader from "../src/BounceLoader";
 
 interface ExampleState {
   color: string;
@@ -71,9 +72,16 @@ class SpinnerExamples extends React.Component<{}, ExampleState> {
           )}
         </div>
 
-        {Object.keys(Spinners).map((name: string) => (
+        <BounceLoader
+          size={100}
+          css={css`
+            color: blue;
+          `}
+        />
+
+        {/* {Object.keys(Spinners).map((name: string) => (
           <LoaderItem key={`loader-${name}`} color={color} name={name} spinner={Spinners[name]} />
-        ))}
+        ))} */}
       </div>
     );
   }

--- a/src/BarLoader.tsx
+++ b/src/BarLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { calculateRgba, heightWidthDefaults } from "./helpers";
+import { calculateRgba, heightWidthDefaults, cssValue } from "./helpers";
 import {
   LoaderHeightWidthProps,
   StyleFunction,
@@ -27,11 +27,11 @@ export class Loader extends React.PureComponent<LoaderHeightWidthProps> {
   public static defaultProps: LoaderHeightWidthProps = heightWidthDefaults(4, 100);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { height, color, heightUnit } = this.props;
+    const { height, color } = this.props;
 
     return css`
       position: absolute;
-      height: ${`${height}${heightUnit}`};
+      height: ${cssValue(height!)};
       overflow: hidden;
       background-color: ${color};
       background-clip: padding-box;
@@ -48,12 +48,12 @@ export class Loader extends React.PureComponent<LoaderHeightWidthProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { width, height, color, heightUnit, widthUnit } = this.props;
+    const { width, height, color } = this.props;
 
     return css`
       position: relative;
-      width: ${`${width}${widthUnit}`};
-      height: ${`${height}${heightUnit}`};
+      width: ${cssValue(width!)};
+      height: ${cssValue(height!)};
       overflow: hidden;
       background-color: ${calculateRgba(color!, 0.2)};
       background-clip: padding-box;

--- a/src/BeatLoader.tsx
+++ b/src/BeatLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue } from "./helpers";
 import { LoaderSizeMarginProps, PrecompiledCss, StyleFunctionWithIndex } from "./interfaces";
 
 const beat: Keyframes = keyframes`
@@ -14,14 +14,14 @@ const beat: Keyframes = keyframes`
 class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       display: inline-block;
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       animation: ${beat} 0.7s ${i % 2 ? "0s" : "0.35s"} infinite linear;
       animation-fill-mode: both;

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -3,13 +3,12 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults, unitConverter } from "./helpers";
+import { sizeDefaults, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
   LoaderSizeProps,
-  StyleFunctionWithIndex,
-  LengthObject
+  StyleFunctionWithIndex
 } from "./interfaces";
 
 const bounce: Keyframes = keyframes`
@@ -20,20 +19,13 @@ const bounce: Keyframes = keyframes`
 class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: Required<LoaderSizeProps> = sizeDefaults(60);
 
-  public cssSize(): string {
-    let { size } = this.props;
-    let sizeWithUnit: LengthObject = unitConverter(size!);
-
-    return `${sizeWithUnit.value}${sizeWithUnit.unit}`;
-  }
-
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color } = this.props;
+    const { color, size } = this.props;
 
     return css`
       position: absolute;
-      height: ${this.cssSize()};
-      width: ${this.cssSize()};
+      height: ${cssValue(size!)};
+      width: ${cssValue(size!)};
       background-color: ${color};
       border-radius: 100%;
       opacity: 0.6;
@@ -45,10 +37,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
+    const { size } = this.props;
+
     return css`
       position: relative;
-      width: ${this.cssSize()};
-      height: ${this.cssSize()};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
     `;
   };
 

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -3,12 +3,13 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, unitConverter } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
   LoaderSizeProps,
-  StyleFunctionWithIndex
+  StyleFunctionWithIndex,
+  LengthObject
 } from "./interfaces";
 
 const bounce: Keyframes = keyframes`
@@ -17,15 +18,22 @@ const bounce: Keyframes = keyframes`
 `;
 
 class Loader extends React.PureComponent<LoaderSizeProps> {
-  public static defaultProps: LoaderSizeProps = sizeDefaults(60);
+  public static defaultProps: Required<LoaderSizeProps> = sizeDefaults(60);
+
+  public cssSize(): string {
+    let { size } = this.props;
+    let sizeWithUnit: LengthObject = unitConverter(size!);
+
+    return `${sizeWithUnit.value}${sizeWithUnit.unit}`;
+  }
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, color, sizeUnit } = this.props;
+    const { color } = this.props;
 
     return css`
       position: absolute;
-      height: ${`${size}${sizeUnit}`};
-      width: ${`${size}${sizeUnit}`};
+      height: ${this.cssSize()};
+      width: ${this.cssSize()};
       background-color: ${color};
       border-radius: 100%;
       opacity: 0.6;
@@ -37,12 +45,10 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
-
     return css`
       position: relative;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${this.cssSize()};
+      height: ${this.cssSize()};
     `;
   };
 

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -1,73 +1,54 @@
-/*
- * List of string constants to represent different props
- */
-const LOADING: string = "loading";
-const COLOR: string = "color";
-const CSS: string = "css";
-const SIZE: string = "size";
-const SIZE_UNIT: string = "sizeUnit";
-const WIDTH: string = "width";
-const WIDTH_UNIT: string = "widthUnit";
-const HEIGHT: string = "height";
-const HEIGHT_UNIT: string = "heightUnit";
-const RADIUS: string = "radius";
-const RADIUS_UNIT: string = "radiusUnit";
-const MARGIN: string = "margin";
+import {
+  LoaderHeightWidthProps,
+  LoaderSizeProps,
+  PrecompiledCss,
+  LoaderSizeMarginProps,
+  LoaderHeightWidthRadiusProps
+} from "../interfaces";
 
 /*
  * DefaultProps object for different loaders
  */
 
-export interface DefaultProps {
-  [key: string]: boolean | string | {} | number;
+interface CommonDefaults {
+  loading: boolean;
+  color: string;
+  css: string | PrecompiledCss;
 }
 
-type HeightWidthFunction = (height: number, width: number) => DefaultProps;
-type HeightWidthRadiusFunction = (height: number, width: number, radius?: number) => DefaultProps;
-type SizeFunction = (size: number) => DefaultProps;
-
-const commonValues: DefaultProps = {
-  [LOADING]: true,
-  [COLOR]: "#000000",
-  [CSS]: {}
+const commonValues: CommonDefaults = {
+  loading: true,
+  color: "#000000",
+  css: ""
 };
 
-const heightWidthValues: HeightWidthFunction = (height: number, width: number): DefaultProps => ({
-  [HEIGHT]: height,
-  [HEIGHT_UNIT]: "px",
-  [WIDTH]: width,
-  [WIDTH_UNIT]: "px"
-});
+export function sizeDefaults(sizeValue: number): Required<LoaderSizeProps> {
+  return Object.assign({}, commonValues, { size: sizeValue });
+}
 
-const sizeValues: SizeFunction = (sizeValue: number): DefaultProps => ({
-  [SIZE]: sizeValue
-});
-
-export const sizeDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
-  return Object.assign({}, commonValues, sizeValues(sizeValue));
-};
-
-export const sizeMarginDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
+export function sizeMarginDefaults(sizeValue: number): Required<LoaderSizeMarginProps> {
   return Object.assign({}, sizeDefaults(sizeValue), {
-    [MARGIN]: "2px"
+    margin: "2px"
   });
-};
+}
 
-export const heightWidthDefaults: HeightWidthFunction = (
+export function heightWidthDefaults(
   height: number,
   width: number
-): DefaultProps => {
-  return Object.assign({}, commonValues, heightWidthValues(height, width));
-};
+): Required<LoaderHeightWidthProps> {
+  return Object.assign({}, commonValues, {
+    height,
+    width
+  });
+}
 
-export const heightWidthRadiusDefaults: HeightWidthRadiusFunction = (
+export function heightWidthRadiusDefaults(
   height: number,
   width: number,
   radius: number = 2
-): DefaultProps => {
+): Required<LoaderHeightWidthRadiusProps> {
   return Object.assign({}, heightWidthDefaults(height, width), {
-    [RADIUS]: radius,
-    [RADIUS_UNIT]: "px",
-    [MARGIN]: "2px"
+    radius,
+    margin: "2px"
   });
-};
+}

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -24,7 +24,7 @@ export interface DefaultProps {
 
 type HeightWidthFunction = (height: number, width: number) => DefaultProps;
 type HeightWidthRadiusFunction = (height: number, width: number, radius?: number) => DefaultProps;
-type SizeFunction = (size: number) => any;
+type SizeFunction = (size: number) => DefaultProps;
 
 const commonValues: DefaultProps = {
   [LOADING]: true,

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -24,7 +24,7 @@ export interface DefaultProps {
 
 type HeightWidthFunction = (height: number, width: number) => DefaultProps;
 type HeightWidthRadiusFunction = (height: number, width: number, radius?: number) => DefaultProps;
-type SizeFunction = (size: number) => DefaultProps;
+type SizeFunction = (size: number) => any;
 
 const commonValues: DefaultProps = {
   [LOADING]: true,
@@ -40,8 +40,7 @@ const heightWidthValues: HeightWidthFunction = (height: number, width: number): 
 });
 
 const sizeValues: SizeFunction = (sizeValue: number): DefaultProps => ({
-  [SIZE]: sizeValue,
-  [SIZE_UNIT]: "px"
+  [SIZE]: sizeValue
 });
 
 export const sizeDefaults: SizeFunction = (sizeValue: number): DefaultProps => {

--- a/src/helpers/unitConverter.ts
+++ b/src/helpers/unitConverter.ts
@@ -27,7 +27,7 @@ const cssUnit: { [unit: string]: boolean } = {
  * @param {(number | string)} size
  * @return {LengthObject} LengthObject
  */
-export function unitConverter(size: number | string): LengthObject {
+export function parseLengthAndUnit(size: number | string): LengthObject {
   if (typeof size === "number") {
     return {
       value: size,
@@ -57,4 +57,16 @@ export function unitConverter(size: number | string): LengthObject {
     value,
     unit: "px"
   };
+}
+
+/**
+ * Take value as an input and return valid css value
+ *
+ * @param {(number | string)} value
+ * @return {string} valid css value
+ */
+export function cssValue(value: number | string): string {
+  let lengthWithunit: LengthObject = parseLengthAndUnit(value!);
+
+  return `${lengthWithunit.value}${lengthWithunit.unit}`;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,20 +20,22 @@ interface CommonProps {
   css?: string | PrecompiledCss;
 }
 
+type LengthType = number | string;
+
 export interface LoaderHeightWidthProps extends CommonProps {
-  height?: number;
-  width?: number;
+  height?: LengthType;
+  width?: LengthType;
 }
 
 export interface LoaderSizeProps extends CommonProps {
-  size?: number | string;
+  size?: LengthType;
 }
 
 export interface LoaderSizeMarginProps extends LoaderSizeProps {
-  margin?: string;
+  margin?: LengthType;
 }
 
 export interface LoaderHeightWidthRadiusProps extends LoaderHeightWidthProps {
-  margin?: string;
-  radius?: number;
+  margin?: LengthType;
+  radius?: LengthType;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,8 +28,7 @@ export interface LoaderHeightWidthProps extends CommonProps {
 }
 
 export interface LoaderSizeProps extends CommonProps {
-  size?: number;
-  sizeUnit?: string;
+  size?: number | string;
 }
 
 export interface LoaderSizeMarginProps extends LoaderSizeProps {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,9 +22,7 @@ interface CommonProps {
 
 export interface LoaderHeightWidthProps extends CommonProps {
   height?: number;
-  heightUnit?: string;
   width?: number;
-  widthUnit?: string;
 }
 
 export interface LoaderSizeProps extends CommonProps {
@@ -38,5 +36,4 @@ export interface LoaderSizeMarginProps extends LoaderSizeProps {
 export interface LoaderHeightWidthRadiusProps extends LoaderHeightWidthProps {
   margin?: string;
   radius?: number;
-  radiusUnit?: string;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -67,7 +67,8 @@
       "variable-declaration",
       "member-variable-declaration"
     ],
-    "semicolon": false
+    "semicolon": false,
+    "object-literal-key-quotes": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
- removed sizeUnit, heightUnit, widthUnit, and radiusUnit from proptypes and interfaces. 
- updated BounceLoader/BarLoader/BeatLoader to remove the unit prop.
- changed `css` prop default to `""` to fix typescript error for `{}` is not `PrecompiledCss`

Tests should continue to fail until all the loaders have the correct props 