### PR TITLE
unit props deprecation: update proptypes and interfaces + all loaders

### DIFF
--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -46,36 +46,69 @@ describe("BarLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", color);
   });
 
-  it("should render the correct height based on props", () => {
-    let height: number = 10;
-    loader = mount(<BarLoader height={height} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+  describe("height prop", () => {
+    it("should render the height with px unit when size is a number", () => {
+      let height: number = 10;
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+    });
+
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let height: string = "18%";
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${height}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}`);
+    });
+
+    it("should render the height with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let height: string = `${length}${unit}`;
+      loader = mount(<BarLoader height={height} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct heightUnit basd on passed in props", () => {
-    let unit: string = "%";
-    loader = mount(<BarLoader heightUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultHeight}${unit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultHeight}${unit}`);
-  });
+  describe("width prop", () => {
+    it("should render the width with px unit when size is a number", () => {
+      let width: number = 10;
+      loader = mount(<BarLoader width={10} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${width}${defaultUnit}`);
+    });
 
-  it("should render the correct width based on props", () => {
-    let width: number = 10;
-    loader = mount(<BarLoader width={10} />);
-    expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${width}${defaultUnit}`);
-  });
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let width: string = "18%";
+      loader = mount(<BarLoader width={width} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${width}`);
+    });
 
-  it("should render the correct widthUnit basd on passed in props", () => {
-    let unit: string = "%";
-    loader = mount(<BarLoader widthUnit="%" />);
-    expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultWidth}${unit}`);
+    it("should render the width with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let width: string = `${length}${unit}`;
+      loader = mount(<BarLoader width={width} />);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderHeightWidthProps } from "../src/interfaces";
 import { heightWidthDefaults } from "../src/helpers";
 
 describe("BarLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderHeightWidthProps, null, BarLoader>;
   let props: LoaderHeightWidthProps;
   let defaultColor: string = "#000000";
   let defaultHeight: number = 4;

--- a/__tests__/BeatLoader-tests.tsx
+++ b/__tests__/BeatLoader-tests.tsx
@@ -12,6 +12,7 @@ describe("BeatLoader", () => {
   let props: LoaderSizeMarginProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultUnit: string = "px";
 
   it("should match snapshot", () => {
@@ -43,28 +44,69 @@ describe("BeatLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", "#e2e2e2");
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<BeatLoader size={18} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<BeatLoader size={18} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct heightUnit basd on props", () => {
-    let unit: string = "%";
-    loader = mount(<BeatLoader sizeUnit="%" />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${unit}`);
-  });
+  describe("margin prop", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<BeatLoader margin={18} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+    });
 
-  it("should render the correct margin props based on props", () => {
-    loader = mount(<BeatLoader margin="4%" />);
-    expect(loader.find("div div")).not.toHaveStyleRule("margin", "2px");
-    expect(loader.find("div div")).toHaveStyleRule("margin", "4%");
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<BeatLoader margin={margin} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${margin}`);
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<BeatLoader margin={margin} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/BeatLoader-tests.tsx
+++ b/__tests__/BeatLoader-tests.tsx
@@ -29,7 +29,7 @@ describe("BeatLoader", () => {
     props = loader.props();
     expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
     expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("margin", "2px");
+    expect(loader.find("div div")).toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
     expect(loader.find("div div")).toHaveStyleRule("background-color", defaultColor);
   });
 

--- a/__tests__/BeatLoader-tests.tsx
+++ b/__tests__/BeatLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeMarginProps } from "../src/interfaces";
 import { sizeMarginDefaults } from "../src/helpers";
 
 describe("BeatLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeMarginProps, null, BeatLoader>;
   let props: LoaderSizeMarginProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 15;

--- a/__tests__/BounceLoader-tests.tsx
+++ b/__tests__/BounceLoader-tests.tsx
@@ -44,27 +44,50 @@ describe("BounceLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", color);
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<BounceLoader size={size} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-    expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
-  });
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<BounceLoader sizeUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${unit}`);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<BounceLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/BounceLoader-tests.tsx
+++ b/__tests__/BounceLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
 
 describe("BounceLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeProps, null, BounceLoader>;
   let props: LoaderSizeProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 60;

--- a/__tests__/CircleLoader-tests.tsx
+++ b/__tests__/CircleLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
 
 describe("CircleLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeProps, null, CircleLoader>;
   let props: LoaderSizeProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 50;

--- a/__tests__/CircleLoader-tests.tsx
+++ b/__tests__/CircleLoader-tests.tsx
@@ -44,28 +44,50 @@ describe("CircleLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("border", `1px solid ${color}`);
   });
 
-  it("should render the correct size for the parent div based on props", () => {
-    let size: number = 18;
-    loader = mount(<CircleLoader size={size} />);
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<CircleLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
 
-    expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
-  });
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<CircleLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-  it("should render the correct heightUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<CircleLoader sizeUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${unit}`);
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<CircleLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/ClimbingBoxLoader-tests.tsx
+++ b/__tests__/ClimbingBoxLoader-tests.tsx
@@ -64,18 +64,38 @@ describe("ClimbingBoxLoader", () => {
     );
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<ClimbingBoxLoader size={size} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("font-size", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("font-size", `${size}${defaultUnit}`);
-  });
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<ClimbingBoxLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "font-size",
+        `${defaultSize}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("font-size", `${size}${defaultUnit}`);
+    });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<ClimbingBoxLoader sizeUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("font-size", `${defaultSize}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("font-size", `${defaultSize}${unit}`);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<ClimbingBoxLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "font-size",
+        `${defaultSize}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("font-size", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<ClimbingBoxLoader size={size} />);
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "font-size",
+        `${defaultSize}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("font-size", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/ClimbingBoxLoader-tests.tsx
+++ b/__tests__/ClimbingBoxLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
 
 describe("ClimbingBoxLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeProps, null, ClimbingBoxLoader>;
   let props: LoaderSizeProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 15;

--- a/__tests__/ClipLoader-tests.tsx
+++ b/__tests__/ClipLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
 
 describe("ClipLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeProps, null, ClipLoader>;
   let props: LoaderSizeProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 35;
@@ -51,13 +51,35 @@ describe("ClipLoader", () => {
     expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<ClipLoader sizeUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<ClipLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<ClipLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<ClipLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/DotLoader-tests.tsx
+++ b/__tests__/DotLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
 
 describe("DotLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderSizeProps, null, DotLoader>;
   let props: LoaderSizeProps;
   let defaultColor: string = "#000000";
   let defaultSize: number = 60;
@@ -48,22 +48,35 @@ describe("DotLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", color);
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<DotLoader size={size} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
-  });
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<DotLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<DotLoader sizeUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<DotLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<DotLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/FadeLoader-tests.tsx
+++ b/__tests__/FadeLoader-tests.tsx
@@ -8,7 +8,7 @@ import { LoaderHeightWidthRadiusProps } from "../src/interfaces";
 import { heightWidthRadiusDefaults } from "../src/helpers";
 
 describe("FadeLoader", () => {
-  let loader: ReactWrapper;
+  let loader: ReactWrapper<LoaderHeightWidthRadiusProps, null, FadeLoader>;
   let props: LoaderHeightWidthRadiusProps;
   let defaultColor: string = "#000000";
   let defaultHeight: number = 15;
@@ -56,94 +56,148 @@ describe("FadeLoader", () => {
     expect(loader.find("div div")).toHaveStyleRule("background-color", "#e2e2e2");
   });
 
-  it("should render the correct height based on props", () => {
-    let height: number = 18;
-    loader = mount(<FadeLoader height={height} />);
+  describe("height props", () => {
+    it("should render the height with px unit when height is a number", () => {
+      let height: number = 18;
+      loader = mount(<FadeLoader height={height} />);
 
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultHeight}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultHeight}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${height}${defaultUnit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${height}${defaultUnit}`);
+      }
+    });
+
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let height: string = "18px";
+      loader = mount(<FadeLoader height={height} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultHeight}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${height}`);
+      }
+    });
+
+    it("should render the height with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let height: string = `${length}${unit}`;
+      loader = mount(<FadeLoader height={height} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultHeight}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      }
+    });
   });
 
-  it("should render the correct heightUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<FadeLoader heightUnit={unit} />);
+  describe("width props", () => {
+    it("should render the width with px unit when width is a number", () => {
+      let width: number = 18;
+      loader = mount(<FadeLoader width={width} />);
 
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultHeight}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultWidth}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultHeight}${unit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${width}${defaultUnit}`);
+      }
+    });
+
+    it("should render the width as is when width is a string with valid css unit", () => {
+      let width: string = "18px";
+      loader = mount(<FadeLoader width={width} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultWidth}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${width}`);
+      }
+    });
+
+    it("should render the width with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let width: string = `${length}${unit}`;
+      loader = mount(<FadeLoader width={width} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultWidth}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      }
+    });
   });
 
-  it("should render the correct width based on props", () => {
-    let width: number = 20;
-    loader = mount(<FadeLoader width={width} />);
+  describe("radius props", () => {
+    it("should render the radius with px unit when radius is a number", () => {
+      let radius: number = 18;
+      loader = mount(<FadeLoader radius={radius} />);
 
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultWidth}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultRadius}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${width}${defaultUnit}`);
-    }
-  });
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border-radius",
+          `${radius}${defaultUnit}`
+        );
+      }
+    });
 
-  it("should render the correct widthUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<FadeLoader widthUnit={unit} />);
+    it("should render the radius as is when radius is a string with valid css unit", () => {
+      let radius: string = "18px";
+      loader = mount(<FadeLoader radius={radius} />);
 
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultWidth}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultRadius}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultWidth}${unit}`);
-    }
-  });
+        expect(loader.find("div div").at(i)).toHaveStyleRule("border-radius", `${radius}`);
+      }
+    });
 
-  it("should render the correct radius based on props", () => {
-    let radius: number = 8;
-    loader = mount(<FadeLoader radius={radius} />);
+    it("should render the radius with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let radius: string = `${length}${unit}`;
+      loader = mount(<FadeLoader radius={radius} />);
 
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "border-radius",
-        `${defaultRadius}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultRadius}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "border-radius",
-        `${radius}${defaultUnit}`
-      );
-    }
-  });
-
-  it("should render the correct radiusUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<FadeLoader radiusUnit={unit} />);
-
-    for (let i: number = 0; i < 8; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "radius",
-        `${defaultRadius}${defaultUnit}`
-      );
-
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "border-radius",
-        `${defaultRadius}${unit}`
-      );
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border-radius",
+          `${length}${defaultUnit}`
+        );
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/FadeLoader-tests.tsx
+++ b/__tests__/FadeLoader-tests.tsx
@@ -14,6 +14,7 @@ describe("FadeLoader", () => {
   let defaultHeight: number = 15;
   let defaultWidth: number = 5;
   let defaultRadius: number = 2;
+  let defaultMargin: number = 2;
   let defaultUnit: string = "px";
 
   it("should match snapshot", () => {
@@ -37,7 +38,10 @@ describe("FadeLoader", () => {
         "width",
         `${defaultWidth}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
       expect(loader.find("div div").at(i)).toHaveStyleRule(
         "border-radius",
         `${defaultRadius}${defaultUnit}`
@@ -196,6 +200,52 @@ describe("FadeLoader", () => {
           "border-radius",
           `${length}${defaultUnit}`
         );
+      }
+    });
+  });
+
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<FadeLoader margin={margin} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
+
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<FadeLoader margin={margin} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<FadeLoader margin={margin} />);
+
+      for (let i: number = 0; i < 8; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
       }
     });
   });

--- a/__tests__/HashLoader-tests.tsx
+++ b/__tests__/HashLoader-tests.tsx
@@ -81,36 +81,112 @@ describe("HashLoader", () => {
     }
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
 
-    loader = mount(<HashLoader sizeUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+      loader = mount(<HashLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
 
-    for (let i: number = 0; i < 2; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize / 5}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize / 5}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "border-radius",
-        `${defaultSize / 10}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultSize / 10}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize / 5}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize / 5}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "border-radius",
-        `${defaultSize / 10}${unit}`
-      );
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size / 5}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size / 5}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border-radius",
+          `${size / 10}${defaultUnit}`
+        );
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let size: string = `${length}${unit}`;
+
+      loader = mount(<HashLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultSize / 10}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length / 5}${unit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length / 5}${unit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border-radius",
+          `${length / 10}${unit}`
+        );
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+
+      loader = mount(<HashLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border-radius",
+          `${defaultSize / 10}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "height",
+          `${length / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "width",
+          `${length / 5}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border-radius",
+          `${length / 10}${defaultUnit}`
+        );
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/MoonLoader-tests.tsx
+++ b/__tests__/MoonLoader-tests.tsx
@@ -68,14 +68,42 @@ describe("MoonLoader", () => {
     expect(loader).toHaveStyleRule("width", `${wrapperSize}${defaultUnit}`);
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<MoonLoader size={size} />);
+      let wrapperSize: number = size + (size / 7) * 2;
+      expect(loader).not.toHaveStyleRule("height", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${wrapperSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${wrapperSize}${defaultUnit}`);
+    });
 
-    loader = mount(<MoonLoader sizeUnit={unit} />);
-    expect(loader).not.toHaveStyleRule("height", `${defaultWrapperSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultWrapperSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultWrapperSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultWrapperSize}${unit}`);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let size: string = `${length}${unit}`;
+
+      loader = mount(<MoonLoader size={size} />);
+      let wrapperSize: number = length + (length / 7) * 2;
+      expect(loader).not.toHaveStyleRule("height", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${wrapperSize}${unit}`);
+      expect(loader).toHaveStyleRule("width", `${wrapperSize}${unit}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+
+      loader = mount(<MoonLoader size={size} />);
+      let wrapperSize: number = length + (length / 7) * 2;
+      expect(loader).not.toHaveStyleRule("height", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultWrapperSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${wrapperSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${wrapperSize}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/PacmanLoader-tests.tsx
+++ b/__tests__/PacmanLoader-tests.tsx
@@ -11,6 +11,7 @@ describe("PacmanLoader", () => {
   let loader: ReactWrapper;
   let props: LoaderSizeMarginProps;
   let defaultSize: number = 25;
+  let defaultMargin: number = 2;
   let defaultColor: string = "#000000";
   let defaultUnit: string = "px";
 
@@ -70,92 +71,204 @@ describe("PacmanLoader", () => {
     }
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<PacmanLoader size={size} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<PacmanLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
 
-    expect(loader.find("div div").at(0)).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultSize / 3}${defaultUnit}`
-    );
-    expect(loader.find("div div").at(1)).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultSize / 3}${defaultUnit}`
-    );
-
-    expect(loader.find("div div").at(0)).toHaveStyleRule("border-radius", `${size}${defaultUnit}`);
-    expect(loader.find("div div").at(1)).toHaveStyleRule("border-radius", `${size}${defaultUnit}`);
-
-    for (let i: number = 2; i < 6; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
+      expect(loader.find("div div").at(0)).not.toHaveStyleRule(
+        "border-radius",
         `${defaultSize / 3}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
+      expect(loader.find("div div").at(1)).not.toHaveStyleRule(
+        "border-radius",
         `${defaultSize / 3}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "top",
-        `${defaultSize}${defaultUnit}`
+
+      expect(loader.find("div div").at(0)).toHaveStyleRule(
+        "border-radius",
+        `${size}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "left",
-        `${defaultSize * 4}${defaultUnit}`
+      expect(loader.find("div div").at(1)).toHaveStyleRule(
+        "border-radius",
+        `${size}${defaultUnit}`
       );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size / 3}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size / 3}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${size}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("left", `${size * 4}${defaultUnit}`);
-    }
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "top",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "left",
+          `${defaultSize * 4}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size / 3}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size / 3}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("left", `${size * 4}${defaultUnit}`);
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let size: string = `${length}${unit}`;
+      loader = mount(<PacmanLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+
+      expect(loader.find("div div").at(0)).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultSize / 3}${defaultUnit}`
+      );
+      expect(loader.find("div div").at(1)).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultSize / 3}${defaultUnit}`
+      );
+
+      expect(loader.find("div div").at(0)).toHaveStyleRule("border-radius", `${size}`);
+      expect(loader.find("div div").at(1)).toHaveStyleRule("border-radius", `${size}`);
+
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "top",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "left",
+          `${defaultSize * 4}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length / 3}${unit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length / 3}${unit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${length}${unit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("left", `${length * 4}${unit}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<PacmanLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+
+      expect(loader.find("div div").at(0)).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultSize / 3}${defaultUnit}`
+      );
+      expect(loader.find("div div").at(1)).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultSize / 3}${defaultUnit}`
+      );
+
+      expect(loader.find("div div").at(0)).toHaveStyleRule(
+        "border-radius",
+        `${length}${defaultUnit}`
+      );
+      expect(loader.find("div div").at(1)).toHaveStyleRule(
+        "border-radius",
+        `${length}${defaultUnit}`
+      );
+
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "top",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "left",
+          `${defaultSize * 4}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "height",
+          `${length / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "width",
+          `${length / 3}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("left", `${length * 4}${defaultUnit}`);
+      }
+    });
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<PacmanLoader sizeUnit={unit} />);
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<PacmanLoader margin={margin} />);
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
 
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let margin: string = `${length}${unit}`;
 
-    expect(loader.find("div div").at(0)).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultSize / 3}${defaultUnit}`
-    );
-    expect(loader.find("div div").at(1)).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultSize / 3}${defaultUnit}`
-    );
+      loader = mount(<PacmanLoader margin={margin} />);
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
 
-    expect(loader.find("div div").at(0)).toHaveStyleRule("border-radius", `${defaultSize}${unit}`);
-    expect(loader.find("div div").at(1)).toHaveStyleRule("border-radius", `${defaultSize}${unit}`);
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
 
-    for (let i: number = 2; i < 6; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize / 3}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize / 3}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "top",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "left",
-        `${defaultSize * 4}${defaultUnit}`
-      );
-
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize / 3}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize / 3}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("left", `${defaultSize * 4}${unit}`);
-    }
+      loader = mount(<PacmanLoader margin={margin} />);
+      for (let i: number = 2; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/PacmanLoader-tests.tsx
+++ b/__tests__/PacmanLoader-tests.tsx
@@ -48,7 +48,10 @@ describe("PacmanLoader", () => {
         "width",
         `${defaultSize / 3}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
       expect(loader.find("div div").at(i)).toHaveStyleRule("top", `${defaultSize}${defaultUnit}`);
       expect(loader.find("div div").at(i)).toHaveStyleRule(
         "left",

--- a/__tests__/PropagateLoader-tests.tsx
+++ b/__tests__/PropagateLoader-tests.tsx
@@ -82,31 +82,87 @@ describe("PropagateLoader", () => {
     }
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<PropagateLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<PropagateLoader size={size} />);
+      for (let i: number = 0; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "font-size",
+          `${defaultSize / 3}${defaultUnit}`
+        );
 
-    for (let i: number = 0; i < 6; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "font-size",
-        `${defaultSize / 3}${defaultUnit}`
-      );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "font-size",
+          `${size / 3}${defaultUnit}`
+        );
+      }
+    });
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "font-size",
-        `${defaultSize / 3}${unit}`
-      );
-    }
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let size: string = `${length}${unit}`;
+
+      loader = mount(<PropagateLoader size={size} />);
+      for (let i: number = 0; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "font-size",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("font-size", `${length / 3}${unit}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<PropagateLoader size={size} />);
+
+      for (let i: number = 0; i < 6; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "font-size",
+          `${defaultSize / 3}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "font-size",
+          `${length / 3}${defaultUnit}`
+        );
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/PulseLoader-test.tsx
+++ b/__tests__/PulseLoader-test.tsx
@@ -11,6 +11,7 @@ describe("PulseLoader", () => {
   let loader: ReactWrapper;
   let props: LoaderSizeMarginProps;
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultColor: string = "#000000";
   let defaultUnit: string = "px";
 
@@ -50,42 +51,108 @@ describe("PulseLoader", () => {
     }
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 18;
-    loader = mount(<PulseLoader size={size} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<PulseLoader size={size} />);
 
-    for (let i: number = 0; i < 3; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<PulseLoader size={size} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<PulseLoader size={size} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      }
+    });
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<PulseLoader sizeUnit={unit} />);
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<PulseLoader margin={margin} />);
 
-    for (let i: number = 0; i < 3; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-    }
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<PulseLoader margin={margin} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<PulseLoader margin={margin} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/PulseLoader-test.tsx
+++ b/__tests__/PulseLoader-test.tsx
@@ -33,7 +33,10 @@ describe("PulseLoader", () => {
         `${defaultSize}${defaultUnit}`
       );
       expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
     }
   });
 

--- a/__tests__/RingLoader-tests.tsx
+++ b/__tests__/RingLoader-tests.tsx
@@ -63,68 +63,106 @@ describe("RingLoader", () => {
     }
   });
 
-  it("should render the correct size based on props", () => {
-    let size: number = 21;
-    loader = mount(<RingLoader size={size} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<RingLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
 
-    for (let i: number = 0; i < 2; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "border",
-        `${defaultSize / 10}${defaultUnit} solid ${defaultColor}`
-      );
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border",
+          `${defaultSize / 10}${defaultUnit} solid ${defaultColor}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "border",
-        `${size / 10}${defaultUnit} solid ${defaultColor}`
-      );
-    }
-  });
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border",
+          `${size / 10}${defaultUnit} solid ${defaultColor}`
+        );
+      }
+    });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<RingLoader sizeUnit={unit} />);
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let length: number = 18;
+      let unit: string = "px";
+      let size: string = `${length}${unit}`;
+      loader = mount(<RingLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
 
-    for (let i: number = 0; i < 2; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "border",
-        `${defaultSize / 10}${defaultUnit} solid ${defaultColor}`
-      );
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border",
+          `${defaultSize / 10}${defaultUnit} solid ${defaultColor}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule(
-        "border",
-        `${defaultSize / 10}${unit} solid ${defaultColor}`
-      );
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border",
+          `${length / 10}${unit} solid ${defaultColor}`
+        );
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<RingLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "border",
+          `${defaultSize / 10}${defaultUnit} solid ${defaultColor}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule(
+          "border",
+          `${length / 10}${defaultUnit} solid ${defaultColor}`
+        );
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/RiseLoader-tests.tsx
+++ b/__tests__/RiseLoader-tests.tsx
@@ -33,7 +33,10 @@ describe("RiseLoader", () => {
         `${defaultSize}${defaultUnit}`
       );
       expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
     }
   });
 

--- a/__tests__/RiseLoader-tests.tsx
+++ b/__tests__/RiseLoader-tests.tsx
@@ -11,6 +11,7 @@ describe("RiseLoader", () => {
   let loader: ReactWrapper;
   let props: LoaderSizeMarginProps;
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultColor: string = "#000000";
   let defaultUnit: string = "px";
 
@@ -69,23 +70,108 @@ describe("RiseLoader", () => {
     }
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<RiseLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<RiseLoader size={size} />);
 
-    for (let i: number = 0; i < 5; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<RiseLoader size={size} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<RiseLoader size={size} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      }
+    });
+  });
+
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<RiseLoader margin={margin} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
+
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<RiseLoader margin={margin} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<RiseLoader margin={margin} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/RotateLoader-tests.tsx
+++ b/__tests__/RotateLoader-tests.tsx
@@ -29,7 +29,7 @@ describe("RotateLoader", () => {
     expect(loader).toHaveStyleRule("background-color", defaultColor);
     expect(loader).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
     expect(loader).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-    expect(loader).toHaveStyleRule("margin", "2px");
+    expect(loader).toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
 
     for (let i: number = 0; i < 2; i++) {
       expect(loader.find("div div").at(i)).toHaveStyleRule("background-color", defaultColor);
@@ -38,7 +38,10 @@ describe("RotateLoader", () => {
         `${defaultSize}${defaultUnit}`
       );
       expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
     }
   });
 

--- a/__tests__/RotateLoader-tests.tsx
+++ b/__tests__/RotateLoader-tests.tsx
@@ -11,6 +11,7 @@ describe("RotateLoader", () => {
   let loader: ReactWrapper;
   let props: LoaderSizeMarginProps;
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultColor: string = "#000000";
   let defaultUnit: string = "px";
 
@@ -83,29 +84,135 @@ describe("RotateLoader", () => {
     }
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<RotateLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<RotateLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
 
-    for (let i: number = 0; i < 2; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<RotateLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<RotateLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      }
+    });
+  });
+
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<RotateLoader margin={margin} />);
+
+      expect(loader).not.toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
+
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<RotateLoader margin={margin} />);
+
+      expect(loader).not.toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("margin", `${margin}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<RotateLoader margin={margin} />);
+
+      expect(loader).not.toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+
+      for (let i: number = 0; i < 2; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/ScaleLoader-tests.tsx
+++ b/__tests__/ScaleLoader-tests.tsx
@@ -14,6 +14,7 @@ describe("ScaleLoader", () => {
   let defaultHeight: number = 35;
   let defaultWidth: number = 4;
   let defaultRadius: number = 2;
+  let defaultMargin: number = 2;
   let defaultUnit: string = "px";
 
   it("should match snapshot", () => {
@@ -59,52 +60,149 @@ describe("ScaleLoader", () => {
     }
   });
 
-  it("should render the correct height based on props", () => {
-    let height: number = 18;
-    loader = mount(<ScaleLoader height={height} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+  describe("height props", () => {
+    it("should render the height with px unit when height is a number", () => {
+      let height: number = 18;
+      loader = mount(<ScaleLoader height={height} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}${defaultUnit}`);
+    });
+
+    it("should render the height as is when height is a string with valid css unit", () => {
+      let height: string = "18px";
+      loader = mount(<ScaleLoader height={height} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${height}`);
+    });
+
+    it("should render the height with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let height: string = `${length}${unit}`;
+      loader = mount(<ScaleLoader height={height} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "height",
+        `${defaultHeight}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct heightUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<ScaleLoader heightUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultHeight}${unit}`);
+  describe("width props", () => {
+    it("should render the width with px unit when width is a number", () => {
+      let width: number = 18;
+      loader = mount(<ScaleLoader width={width} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${width}${defaultUnit}`);
+    });
+
+    it("should render the width as is when width is a string with valid css unit", () => {
+      let width: string = "18px";
+      loader = mount(<ScaleLoader width={width} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${width}`);
+    });
+
+    it("should render the width with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let width: string = `${length}${unit}`;
+      loader = mount(<ScaleLoader width={width} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct width based on props", () => {
-    let width: number = 20;
-    loader = mount(<ScaleLoader width={width} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${width}${defaultUnit}`);
+  describe("radius props", () => {
+    it("should render the radius with px unit when radius is a number", () => {
+      let radius: number = 18;
+      loader = mount(<ScaleLoader radius={radius} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultRadius}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("border-radius", `${radius}${defaultUnit}`);
+    });
+
+    it("should render the radius as is when radius is a string with valid css unit", () => {
+      let radius: string = "18px";
+      loader = mount(<ScaleLoader radius={radius} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultRadius}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("border-radius", `${radius}`);
+    });
+
+    it("should render the radius with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let radius: string = `${length}${unit}`;
+      loader = mount(<ScaleLoader radius={radius} />);
+
+      expect(loader.find("div div")).not.toHaveStyleRule(
+        "border-radius",
+        `${defaultRadius}${defaultUnit}`
+      );
+      expect(loader.find("div div")).toHaveStyleRule("border-radius", `${length}${defaultUnit}`);
+    });
   });
 
-  it("should render the correct widthUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<ScaleLoader widthUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
-    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultWidth}${unit}`);
-  });
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<ScaleLoader margin={margin} />);
 
-  it("should render the correct radius based on props", () => {
-    let radius: number = 5;
-    loader = mount(<ScaleLoader radius={radius} />);
-    expect(loader.find("div div")).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultRadius}${defaultUnit}`
-    );
-    expect(loader.find("div div")).toHaveStyleRule("border-radius", `${radius}${defaultUnit}`);
-  });
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
 
-  it("should render the correct radiusUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<ScaleLoader radiusUnit={unit} />);
-    expect(loader.find("div div")).not.toHaveStyleRule(
-      "border-radius",
-      `${defaultRadius}${defaultUnit}`
-    );
-    expect(loader.find("div div")).toHaveStyleRule("border-radius", `${defaultRadius}${unit}`);
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<ScaleLoader margin={margin} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<ScaleLoader margin={margin} />);
+
+      for (let i: number = 0; i < 5; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/ScaleLoader-tests.tsx
+++ b/__tests__/ScaleLoader-tests.tsx
@@ -42,7 +42,10 @@ describe("ScaleLoader", () => {
         "border-radius",
         `${defaultRadius}${defaultUnit}`
       );
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
     }
   });
 

--- a/__tests__/SkewLoader-tests.tsx
+++ b/__tests__/SkewLoader-tests.tsx
@@ -74,26 +74,80 @@ describe("SkewLoader", () => {
     expect(loader).toHaveStyleRule("border-bottom", `${size}${defaultUnit} solid ${defaultColor}`);
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<SkewLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<SkewLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule(
-      "border-left",
-      `${defaultSize}${defaultUnit} solid transparent`
-    );
-    expect(loader).not.toHaveStyleRule(
-      "border-right",
-      `${defaultSize}${defaultUnit} solid transparent`
-    );
-    expect(loader).not.toHaveStyleRule(
-      "border-bottom",
-      `${defaultSize}${defaultUnit} solid ${defaultColor}`
-    );
+      expect(loader).not.toHaveStyleRule(
+        "border-left",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-right",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-bottom",
+        `${defaultSize}${defaultUnit} solid ${defaultColor}`
+      );
 
-    expect(loader).toHaveStyleRule("border-left", `${defaultSize}${unit} solid transparent`);
-    expect(loader).toHaveStyleRule("border-right", `${defaultSize}${unit} solid transparent`);
-    expect(loader).toHaveStyleRule("border-bottom", `${defaultSize}${unit} solid ${defaultColor}`);
+      expect(loader).toHaveStyleRule("border-left", `${size}${defaultUnit} solid transparent`);
+      expect(loader).toHaveStyleRule("border-right", `${size}${defaultUnit} solid transparent`);
+      expect(loader).toHaveStyleRule(
+        "border-bottom",
+        `${size}${defaultUnit} solid ${defaultColor}`
+      );
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<SkewLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule(
+        "border-left",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-right",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-bottom",
+        `${defaultSize}${defaultUnit} solid ${defaultColor}`
+      );
+
+      expect(loader).toHaveStyleRule("border-left", `${size} solid transparent`);
+      expect(loader).toHaveStyleRule("border-right", `${size} solid transparent`);
+      expect(loader).toHaveStyleRule("border-bottom", `${size} solid ${defaultColor}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<SkewLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule(
+        "border-left",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-right",
+        `${defaultSize}${defaultUnit} solid transparent`
+      );
+      expect(loader).not.toHaveStyleRule(
+        "border-bottom",
+        `${defaultSize}${defaultUnit} solid ${defaultColor}`
+      );
+
+      expect(loader).toHaveStyleRule("border-left", `${length}${defaultUnit} solid transparent`);
+      expect(loader).toHaveStyleRule("border-right", `${length}${defaultUnit} solid transparent`);
+      expect(loader).toHaveStyleRule(
+        "border-bottom",
+        `${length}${defaultUnit} solid ${defaultColor}`
+      );
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/SquareLoader-tests.tsx
+++ b/__tests__/SquareLoader-tests.tsx
@@ -53,15 +53,41 @@ describe("SquareLoader", () => {
     expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<SquareLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<SquareLoader size={size} />);
 
-    expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
-    expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
-    expect(loader).toHaveStyleRule("height", `${defaultSize}${unit}`);
-    expect(loader).toHaveStyleRule("width", `${defaultSize}${unit}`);
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<SquareLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<SquareLoader size={size} />);
+
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/SyncLoader-tests.tsx
+++ b/__tests__/SyncLoader-tests.tsx
@@ -11,6 +11,7 @@ describe("SyncLoader", () => {
   let loader: ReactWrapper;
   let props: LoaderSizeMarginProps;
   let defaultSize: number = 15;
+  let defaultMargin: number = 2;
   let defaultColor: string = "#000000";
   let defaultUnit: string = "px";
 
@@ -32,7 +33,10 @@ describe("SyncLoader", () => {
         `${defaultSize}${defaultUnit}`
       );
       expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("margin", "2px");
+      expect(loader.find("div div").at(i)).toHaveStyleRule(
+        "margin",
+        `${defaultMargin}${defaultUnit}`
+      );
     }
   });
 
@@ -70,23 +74,108 @@ describe("SyncLoader", () => {
     }
   });
 
-  it("should render the correct sizeUnit based on props", () => {
-    let unit: string = "%";
-    loader = mount(<SyncLoader sizeUnit={unit} />);
+  describe("size props", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<SyncLoader size={size} />);
 
-    for (let i: number = 0; i < 3; i++) {
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "height",
-        `${defaultSize}${defaultUnit}`
-      );
-      expect(loader.find("div div").at(i)).not.toHaveStyleRule(
-        "width",
-        `${defaultSize}${defaultUnit}`
-      );
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
 
-      expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${defaultSize}${unit}`);
-      expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${defaultSize}${unit}`);
-    }
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      }
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<SyncLoader size={size} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${size}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${size}`);
+      }
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<SyncLoader size={size} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "height",
+          `${defaultSize}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "width",
+          `${defaultSize}${defaultUnit}`
+        );
+
+        expect(loader.find("div div").at(i)).toHaveStyleRule("height", `${length}${defaultUnit}`);
+        expect(loader.find("div div").at(i)).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      }
+    });
+  });
+
+  describe("margin props", () => {
+    it("should render the margin with px unit when margin is a number", () => {
+      let margin: number = 18;
+      loader = mount(<SyncLoader margin={margin} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}${defaultUnit}`);
+      }
+    });
+
+    it("should render the margin as is when margin is a string with valid css unit", () => {
+      let margin: string = "18px";
+      loader = mount(<SyncLoader margin={margin} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${margin}`);
+      }
+    });
+
+    it("should render the margin with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let margin: string = `${length}${unit}`;
+      loader = mount(<SyncLoader margin={margin} />);
+
+      for (let i: number = 0; i < 3; i++) {
+        expect(loader.find("div div").at(i)).not.toHaveStyleRule(
+          "margin",
+          `${defaultMargin}${defaultUnit}`
+        );
+        expect(loader.find("div div").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
+      }
+    });
   });
 
   it("should render the css override based on props", () => {

--- a/__tests__/__snapshots__/BarLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BarLoader-tests.tsx.snap
@@ -76,12 +76,10 @@ exports[`BarLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   height={4}
-  heightUnit="px"
   loading={true}
   width={100}
-  widthUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
@@ -61,11 +61,10 @@ exports[`BeatLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   margin="2px"
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-3"

--- a/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
@@ -63,7 +63,7 @@ exports[`BeatLoader should match snapshot 1`] = `
   color="#000000"
   css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
 >
   <div

--- a/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
@@ -67,10 +67,9 @@ exports[`BounceLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={60}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
@@ -199,10 +199,9 @@ exports[`CircleLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={50}
-  sizeUnit="px"
 >
   <div
     className="emotion-5"

--- a/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
@@ -118,10 +118,9 @@ exports[`ClimbingBoxLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-3"

--- a/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
@@ -38,10 +38,9 @@ exports[`ClipLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={35}
-  sizeUnit="px"
 >
   <div
     className="emotion-0"

--- a/__tests__/__snapshots__/DotLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/DotLoader-tests.tsx.snap
@@ -77,10 +77,9 @@ exports[`DotLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={60}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
@@ -246,15 +246,12 @@ exports[`FadeLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   height={15}
-  heightUnit="px"
   loading={true}
-  margin="2px"
+  margin={2}
   radius={2}
-  radiusUnit="px"
   width={5}
-  widthUnit="px"
 >
   <div
     className="emotion-8"

--- a/__tests__/__snapshots__/GridLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/GridLoader-tests.tsx.snap
@@ -43,11 +43,10 @@ exports[`GridLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-9"

--- a/__tests__/__snapshots__/HashLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/HashLoader-tests.tsx.snap
@@ -90,10 +90,9 @@ exports[`HashLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={50}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
@@ -51,10 +51,9 @@ exports[`MoonLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={60}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
@@ -188,11 +188,10 @@ exports[`PacmanLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={25}
-  sizeUnit="px"
 >
   <div
     className="emotion-6"

--- a/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
@@ -229,10 +229,9 @@ exports[`PropagateLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-6"

--- a/__tests__/__snapshots__/PulseLoader-test.tsx.snap
+++ b/__tests__/__snapshots__/PulseLoader-test.tsx.snap
@@ -111,11 +111,10 @@ exports[`PulseLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-3"

--- a/__tests__/__snapshots__/RingLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RingLoader-tests.tsx.snap
@@ -75,10 +75,9 @@ exports[`RingLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={60}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
@@ -93,11 +93,10 @@ exports[`RiseLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-5"

--- a/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
@@ -61,11 +61,10 @@ exports[`RotateLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-2"

--- a/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
@@ -168,15 +168,12 @@ exports[`ScaleLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   height={35}
-  heightUnit="px"
   loading={true}
-  margin="2px"
+  margin={2}
   radius={2}
-  radiusUnit="px"
   width={4}
-  widthUnit="px"
 >
   <div
     className="emotion-5"

--- a/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
@@ -42,10 +42,9 @@ exports[`SkewLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={20}
-  sizeUnit="px"
 >
   <div
     className="emotion-0"

--- a/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
@@ -40,10 +40,9 @@ exports[`SquareLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
   size={50}
-  sizeUnit="px"
 >
   <div
     className="emotion-0"

--- a/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
@@ -102,11 +102,10 @@ exports[`SyncLoader should match snapshot 1`] = `
 
 <Loader
   color="#000000"
-  css={Object {}}
+  css=""
   loading={true}
-  margin="2px"
+  margin={2}
   size={15}
-  sizeUnit="px"
 >
   <div
     className="emotion-3"

--- a/__tests__/helpers/proptypes-tests.ts
+++ b/__tests__/helpers/proptypes-tests.ts
@@ -1,10 +1,15 @@
 import {
   sizeDefaults,
-  DefaultProps,
   sizeMarginDefaults,
   heightWidthDefaults,
   heightWidthRadiusDefaults
 } from "../../src/helpers";
+import {
+  LoaderSizeProps,
+  LoaderSizeMarginProps,
+  LoaderHeightWidthRadiusProps,
+  LoaderHeightWidthProps
+} from "../../src/interfaces";
 
 describe("Default Props functions for different loaders", () => {
   describe("sizeDefaults", () => {
@@ -13,23 +18,21 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = sizeDefaults(1);
+      let defaultProps: Required<LoaderSizeProps> = sizeDefaults(1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the size as the passed in size value", () => {
-      let defaultProps1: DefaultProps = sizeDefaults(1);
+      let defaultProps1: Required<LoaderSizeProps> = sizeDefaults(1);
       expect(defaultProps1).toHaveProperty("size");
       expect(defaultProps1.size).toEqual(1);
-      expect(defaultProps1).toHaveProperty("sizeUnit");
-      expect(defaultProps1.sizeUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = sizeDefaults(2);
+      let defaultProps2: Required<LoaderSizeProps> = sizeDefaults(2);
       expect(defaultProps2).toHaveProperty("size");
       expect(defaultProps2.size).toEqual(2);
     });
@@ -41,25 +44,23 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = sizeMarginDefaults(1);
+      let defaultProps: Required<LoaderSizeMarginProps> = sizeMarginDefaults(1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the size as the passed in size value", () => {
-      let defaultProps1: DefaultProps = sizeMarginDefaults(1);
+      let defaultProps1: Required<LoaderSizeMarginProps> = sizeMarginDefaults(1);
       expect(defaultProps1).toHaveProperty("size");
       expect(defaultProps1.size).toEqual(1);
-      expect(defaultProps1).toHaveProperty("sizeUnit");
-      expect(defaultProps1.sizeUnit).toEqual("px");
       expect(defaultProps1).toHaveProperty("margin");
       expect(defaultProps1.margin).toEqual("2px");
 
-      let defaultProps2: DefaultProps = sizeMarginDefaults(2);
+      let defaultProps2: Required<LoaderSizeMarginProps> = sizeMarginDefaults(2);
       expect(defaultProps2).toHaveProperty("size");
       expect(defaultProps2.size).toEqual(2);
     });
@@ -71,27 +72,23 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = heightWidthDefaults(1, 1);
+      let defaultProps: Required<LoaderHeightWidthProps> = heightWidthDefaults(1, 1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the height/width as the passed in height/width value", () => {
-      let defaultProps1: DefaultProps = heightWidthDefaults(1, 2);
+      let defaultProps1: Required<LoaderHeightWidthProps> = heightWidthDefaults(1, 2);
       expect(defaultProps1).toHaveProperty("height");
       expect(defaultProps1.height).toEqual(1);
       expect(defaultProps1).toHaveProperty("width");
       expect(defaultProps1.width).toEqual(2);
-      expect(defaultProps1).toHaveProperty("heightUnit");
-      expect(defaultProps1.heightUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("widthUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = heightWidthDefaults(3, 4);
+      let defaultProps2: Required<LoaderHeightWidthProps> = heightWidthDefaults(3, 4);
       expect(defaultProps2).toHaveProperty("height");
       expect(defaultProps2.height).toEqual(3);
       expect(defaultProps2).toHaveProperty("width");
@@ -105,31 +102,33 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("should return an object containing the common props: loading, color, css", () => {
-      let defaultProps: DefaultProps = heightWidthRadiusDefaults(1, 1, 1);
+      let defaultProps: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(1, 1, 1);
       expect(defaultProps).toHaveProperty("loading");
       expect(defaultProps.loading).toEqual(true);
       expect(defaultProps).toHaveProperty("color");
       expect(defaultProps.color).toEqual("#000000");
       expect(defaultProps).toHaveProperty("css");
-      expect(defaultProps.css).toEqual({});
+      expect(defaultProps.css).toEqual("");
     });
 
     it("should return the height/width as the passed in height/width value", () => {
-      let defaultProps1: DefaultProps = heightWidthRadiusDefaults(1, 2, 3);
+      let defaultProps1: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(
+        1,
+        2,
+        3
+      );
       expect(defaultProps1).toHaveProperty("height");
       expect(defaultProps1.height).toEqual(1);
       expect(defaultProps1).toHaveProperty("width");
       expect(defaultProps1.width).toEqual(2);
       expect(defaultProps1).toHaveProperty("radius");
       expect(defaultProps1.radius).toEqual(3);
-      expect(defaultProps1).toHaveProperty("heightUnit");
-      expect(defaultProps1.heightUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("widthUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
-      expect(defaultProps1).toHaveProperty("radiusUnit");
-      expect(defaultProps1.widthUnit).toEqual("px");
 
-      let defaultProps2: DefaultProps = heightWidthRadiusDefaults(4, 5, 6);
+      let defaultProps2: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(
+        4,
+        5,
+        6
+      );
       expect(defaultProps2).toHaveProperty("height");
       expect(defaultProps2.height).toEqual(4);
       expect(defaultProps2).toHaveProperty("width");
@@ -139,7 +138,7 @@ describe("Default Props functions for different loaders", () => {
     });
 
     it("radius value should default to 2", () => {
-      let defaultProps: DefaultProps = heightWidthRadiusDefaults(5, 6);
+      let defaultProps: Required<LoaderHeightWidthRadiusProps> = heightWidthRadiusDefaults(5, 6);
       expect(defaultProps.radius).toEqual(2);
     });
   });

--- a/__tests__/helpers/proptypes-tests.ts
+++ b/__tests__/helpers/proptypes-tests.ts
@@ -58,7 +58,7 @@ describe("Default Props functions for different loaders", () => {
       expect(defaultProps1).toHaveProperty("size");
       expect(defaultProps1.size).toEqual(1);
       expect(defaultProps1).toHaveProperty("margin");
-      expect(defaultProps1.margin).toEqual("2px");
+      expect(defaultProps1.margin).toEqual(2);
 
       let defaultProps2: Required<LoaderSizeMarginProps> = sizeMarginDefaults(2);
       expect(defaultProps2).toHaveProperty("size");

--- a/__tests__/helpers/unitConverter-tests.ts
+++ b/__tests__/helpers/unitConverter-tests.ts
@@ -1,38 +1,59 @@
-import { unitConverter } from "../../src/helpers";
+import { parseLengthAndUnit, cssValue } from "../../src/helpers";
 import { LengthObject } from "../../src/interfaces";
 
 describe("unitConverter", () => {
-  let spy: jest.SpyInstance = jest.spyOn(console, "warn");
-  let output: LengthObject = {
-    value: 12,
-    unit: "px"
-  };
-
-  it("is a function", () => {
-    expect(typeof unitConverter).toEqual("function");
-  });
-
-  it("takes a number as the input and append px to the value", () => {
-    expect(unitConverter(12)).toEqual(output);
-    expect(spy).not.toBeCalled();
-  });
-
-  it("take a string with valid integer css unit and return an object with value and unit", () => {
-    expect(unitConverter("12px")).toEqual(output);
-    expect(spy).not.toBeCalled();
-  });
-
-  it("take a string with valid css float unit and return an object with value and unit", () => {
+  describe("parseLengthAndUnit", () => {
+    let spy: jest.SpyInstance = jest.spyOn(console, "warn");
     let output: LengthObject = {
-      value: 12.5,
+      value: 12,
       unit: "px"
     };
-    expect(unitConverter("12.5px")).toEqual(output);
-    expect(spy).not.toBeCalled();
+
+    it("is a function", () => {
+      expect(typeof parseLengthAndUnit).toEqual("function");
+    });
+
+    it("takes a number as the input and append px to the value", () => {
+      expect(parseLengthAndUnit(12)).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("take a string with valid integer css unit and return an object with value and unit", () => {
+      expect(parseLengthAndUnit("12px")).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("take a string with valid css float unit and return an object with value and unit", () => {
+      let output: LengthObject = {
+        value: 12.5,
+        unit: "px"
+      };
+      expect(parseLengthAndUnit("12.5px")).toEqual(output);
+      expect(spy).not.toBeCalled();
+    });
+
+    it("takes an invalid css unit and default the value to px", () => {
+      expect(parseLengthAndUnit("12fd")).toEqual(output);
+      expect(spy).toBeCalled();
+    });
   });
 
-  it("takes an invalid css unit and default the value to px", () => {
-    expect(unitConverter("12fd")).toEqual(output);
-    expect(spy).toBeCalled();
+  describe("cssValue", () => {
+    it("is a function", () => {
+      expect(typeof cssValue).toEqual("function");
+    });
+
+    it("takes a number as the input and append px to the value", () => {
+      expect(cssValue(12)).toEqual("12px");
+    });
+
+    it("takes a string with valid css unit as the input and return the value", () => {
+      expect(cssValue("12%")).toEqual("12%");
+      expect(cssValue("12em")).toEqual("12em");
+    });
+
+    it("takes a string with invalid css unit as the input and default to px", () => {
+      expect(cssValue("12qw")).toEqual("12px");
+    });
   });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
     ga('send', 'pageview');
 
   </script>
-<script type="text/javascript" src="vendors~main-e50b6df8ee587f0399c5.js"></script><script type="text/javascript" src="main-e50b6df8ee587f0399c5.js"></script></head>
+<script type="text/javascript" src="js/vendors~main-110e84b40e5352118e45.js"></script><script type="text/javascript" src="js/main-110e84b40e5352118e45.js"></script></head>
 
 <body>
   <header id='header'>

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -6,7 +6,6 @@ import { ColorResult } from "react-color";
 
 import { Code, ColorPicker, LoaderItem } from "./components";
 import * as Spinners from "../src";
-import BounceLoader from "../src/BounceLoader";
 
 interface ExampleState {
   color: string;
@@ -72,16 +71,9 @@ class SpinnerExamples extends React.Component<{}, ExampleState> {
           )}
         </div>
 
-        <BounceLoader
-          size={100}
-          css={css`
-            color: blue;
-          `}
-        />
-
-        {/* {Object.keys(Spinners).map((name: string) => (
+        {Object.keys(Spinners).map((name: string) => (
           <LoaderItem key={`loader-${name}`} color={color} name={name} spinner={Spinners[name]} />
-        ))} */}
+        ))}
       </div>
     );
   }

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -6,6 +6,7 @@ import { ColorResult } from "react-color";
 
 import { Code, ColorPicker, LoaderItem } from "./components";
 import * as Spinners from "../src";
+import BounceLoader from "../src/BounceLoader";
 
 interface ExampleState {
   color: string;
@@ -71,9 +72,16 @@ class SpinnerExamples extends React.Component<{}, ExampleState> {
           )}
         </div>
 
-        {Object.keys(Spinners).map((name: string) => (
+        <BounceLoader
+          size={100}
+          css={css`
+            color: blue;
+          `}
+        />
+
+        {/* {Object.keys(Spinners).map((name: string) => (
           <LoaderItem key={`loader-${name}`} color={color} name={name} spinner={Spinners[name]} />
-        ))}
+        ))} */}
       </div>
     );
   }

--- a/src/BarLoader.tsx
+++ b/src/BarLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { calculateRgba, heightWidthDefaults } from "./helpers";
+import { calculateRgba, heightWidthDefaults, cssValue } from "./helpers";
 import {
   LoaderHeightWidthProps,
   StyleFunction,
@@ -27,11 +27,11 @@ export class Loader extends React.PureComponent<LoaderHeightWidthProps> {
   public static defaultProps: LoaderHeightWidthProps = heightWidthDefaults(4, 100);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { height, color, heightUnit } = this.props;
+    const { height, color } = this.props;
 
     return css`
       position: absolute;
-      height: ${`${height}${heightUnit}`};
+      height: ${cssValue(height!)};
       overflow: hidden;
       background-color: ${color};
       background-clip: padding-box;
@@ -48,12 +48,12 @@ export class Loader extends React.PureComponent<LoaderHeightWidthProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { width, height, color, heightUnit, widthUnit } = this.props;
+    const { width, height, color } = this.props;
 
     return css`
       position: relative;
-      width: ${`${width}${widthUnit}`};
-      height: ${`${height}${heightUnit}`};
+      width: ${cssValue(width!)};
+      height: ${cssValue(height!)};
       overflow: hidden;
       background-color: ${calculateRgba(color!, 0.2)};
       background-clip: padding-box;

--- a/src/BeatLoader.tsx
+++ b/src/BeatLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue } from "./helpers";
 import { LoaderSizeMarginProps, PrecompiledCss, StyleFunctionWithIndex } from "./interfaces";
 
 const beat: Keyframes = keyframes`
@@ -14,14 +14,14 @@ const beat: Keyframes = keyframes`
 class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       display: inline-block;
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       animation: ${beat} 0.7s ${i % 2 ? "0s" : "0.35s"} infinite linear;
       animation-fill-mode: both;

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -17,15 +17,15 @@ const bounce: Keyframes = keyframes`
 `;
 
 class Loader extends React.PureComponent<LoaderSizeProps> {
-  public static defaultProps: LoaderSizeProps = sizeDefaults(60);
+  public static defaultProps: Required<LoaderSizeProps> = sizeDefaults(60);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, color, sizeUnit } = this.props;
+    const { color, size } = this.props;
 
     return css`
       position: absolute;
-      height: ${`${size}${sizeUnit}`};
-      width: ${`${size}${sizeUnit}`};
+      height: ${cssValue(size!)};
+      width: ${cssValue(size!)};
       background-color: ${color};
       border-radius: 100%;
       opacity: 0.6;
@@ -37,12 +37,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: relative;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
     `;
   };
 

--- a/src/CircleLoader.tsx
+++ b/src/CircleLoader.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, cssValue, parseLengthAndUnit } from "./helpers";
 import { Keyframes } from "@emotion/serialize";
 import {
   StyleFunction,
@@ -21,12 +21,13 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(50);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, color, sizeUnit } = this.props;
+    const { size, color } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: absolute;
-      height: ${`${size! * (1 - i / 10)}${sizeUnit}`};
-      width: ${`${size! * (1 - i / 10)}${sizeUnit}`};
+      height: ${`${value! * (1 - i / 10)}${unit}`};
+      width: ${`${value! * (1 - i / 10)}${unit}`};
       border: 1px solid ${color};
       border-radius: 100%;
       transition: 2s;
@@ -40,12 +41,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: relative;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
     `;
   };
 

--- a/src/ClimbingBoxLoader.tsx
+++ b/src/ClimbingBoxLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, cssValue } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const climbingBox: Keyframes = keyframes`
@@ -42,7 +42,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: absolute;
@@ -52,7 +52,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
       margin-left: -2.7em;
       width: 5.4em;
       height: 5.4em;
-      font-size: ${`${size}${sizeUnit}`};
+      font-size: ${cssValue(size!)};
     `;
   };
 

--- a/src/ClipLoader.tsx
+++ b/src/ClipLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers/proptypes";
+import { sizeDefaults, cssValue } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const clip: Keyframes = keyframes`
@@ -16,12 +16,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(35);
 
   public style: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
 
     return css`
       background: transparent !important;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
       border-radius: 100%;
       border: 2px solid;
       border-color: ${color};

--- a/src/DotLoader.tsx
+++ b/src/DotLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, parseLengthAndUnit, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -24,14 +24,15 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(60);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: absolute;
       top: ${i % 2 ? "0" : "auto"};
       bottom: ${i % 2 ? "auto" : "0"};
-      height: ${`${size! / 2}${sizeUnit}`};
-      width: ${`${size! / 2}${sizeUnit}`};
+      height: ${`${value! / 2}${unit}`};
+      width: ${`${value! / 2}${unit}`};
       background-color: ${color};
       border-radius: 100%;
       animation-fill-mode: forwards;
@@ -40,12 +41,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: relative;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
       animation-fill-mode: forwards;
       animation: ${rotate} 2s 0s infinite linear;
     `;

--- a/src/FadeLoader.tsx
+++ b/src/FadeLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { heightWidthRadiusDefaults } from "./helpers";
+import { heightWidthRadiusDefaults, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -22,15 +22,15 @@ class Loader extends React.PureComponent<LoaderHeightWidthRadiusProps> {
   public quarter: number = this.radius / 2 + this.radius / 5.5;
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { height, width, margin, color, radius, widthUnit, heightUnit, radiusUnit } = this.props;
+    const { height, width, margin, color, radius } = this.props;
 
     return css`
       position: absolute;
-      width: ${`${width}${widthUnit}`};
-      height: ${`${height}${heightUnit}`};
-      margin: ${margin};
+      width: ${cssValue(width!)};
+      height: ${cssValue(height!)};
+      margin: ${cssValue(margin!)};
       background-color: ${color};
-      border-radius: ${`${radius}${radiusUnit}`};
+      border-radius: ${cssValue(radius!)};
       transition: 2s;
       animation-fill-mode: "both";
       animation: ${fade} 1.2s ${i * 0.12}s infinite ease-in-out;

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -3,12 +3,13 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue, parseLengthAndUnit } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
   LoaderSizeMarginProps,
-  StyleFunctionWithIndex
+  StyleFunctionWithIndex,
+  LengthObject
 } from "./interfaces";
 
 const grid: Keyframes = keyframes`
@@ -24,14 +25,14 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
 
   public style: StyleFunctionWithIndex = (rand: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       display: inline-block;
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       animation-fill-mode: "both";
       animation: ${grid} ${rand / 100 + 0.6}s ${rand / 100 - 0.2}s infinite ease;
@@ -39,10 +40,15 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit, margin } = this.props;
+    const { size, margin } = this.props;
+    let sizeWithUnit: LengthObject = parseLengthAndUnit(size!);
+    let marginWithUnit: LengthObject = parseLengthAndUnit(margin!);
+
+    let width: string = `${parseFloat(sizeWithUnit.value.toString()) * 3 +
+      parseFloat(marginWithUnit.value.toString()) * 6}${sizeWithUnit.unit}`;
 
     return css`
-      width: ${`${parseFloat(size!.toString()) * 3 + parseFloat(margin!) * 6}${sizeUnit}`};
+      width: ${width};
       font-size: 0;
     `;
   };

--- a/src/HashLoader.tsx
+++ b/src/HashLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { calculateRgba, sizeDefaults } from "./helpers/index";
+import { calculateRgba, sizeDefaults, parseLengthAndUnit, cssValue } from "./helpers/index";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -17,14 +17,16 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
 
   public thickness: CalcFunction<number> = (): number => {
     const { size } = this.props;
+    let { value } = parseLengthAndUnit(size!);
 
-    return size! / 5;
+    return value / 5;
   };
 
   public lat: CalcFunction<number> = (): number => {
     const { size } = this.props;
+    let { value } = parseLengthAndUnit(size!);
 
-    return (size! - this.thickness()) / 2;
+    return (value! - this.thickness()) / 2;
   };
 
   public offset: CalcFunction<number> = (): number => this.lat() - this.thickness();
@@ -36,7 +38,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public before: CalcFunction<Keyframes> = (): Keyframes => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     const color: string = this.color();
     const lat: number = this.lat();
@@ -45,14 +47,14 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
 
     return keyframes`
       0% {width: ${thickness}px;box-shadow: ${lat}px ${-offset}px ${color}, ${-lat}px ${offset}px ${color}}
-      35% {width: ${`${size}${sizeUnit}`};box-shadow: 0 ${-offset}px ${color}, 0 ${offset}px ${color}}
+      35% {width: ${cssValue(size!)};box-shadow: 0 ${-offset}px ${color}, 0 ${offset}px ${color}}
       70% {width: ${thickness}px;box-shadow: ${-lat}px ${-offset}px ${color}, ${lat}px ${offset}px ${color}}
       100% {box-shadow: ${lat}px ${-offset}px ${color}, ${-lat}px ${offset}px ${color}}
     `;
   };
 
   public after: CalcFunction<Keyframes> = (): Keyframes => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     const color: string = this.color();
     const lat: number = this.lat();
@@ -61,14 +63,15 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
 
     return keyframes`
       0% {height: ${thickness}px;box-shadow: ${offset}px ${lat}px ${color}, ${-offset}px ${-lat}px ${color}}
-      35% {height: ${`${size}${sizeUnit}`};box-shadow: ${offset}px 0 ${color}, ${-offset}px 0 ${color}}
+      35% {height: ${cssValue(size!)};box-shadow: ${offset}px 0 ${color}, ${-offset}px 0 ${color}}
       70% {height: ${thickness}px;box-shadow: ${offset}px ${-lat}px ${color}, ${-offset}px ${lat}px ${color}}
       100% {box-shadow: ${offset}px ${lat}px ${color}, ${-offset}px ${-lat}px ${color}}
     `;
   };
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: absolute;
@@ -76,9 +79,9 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
       top: 50%;
       left: 50%;
       display: block;
-      width: ${`${size! / 5}${sizeUnit}`};
-      height: ${`${size! / 5}${sizeUnit}`};
-      border-radius: ${`${size! / 10}${sizeUnit}`};
+      width: ${`${value / 5}${unit}`};
+      height: ${`${value / 5}${unit}`};
+      border-radius: ${`${value / 10}${unit}`};
       transform: translate(-50%, -50%);
       animation-fill-mode: none;
       animation: ${i === 1 ? this.before() : this.after()} 2s infinite;
@@ -86,12 +89,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: relative;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
       transform: rotate(165deg);
     `;
   };

--- a/src/MoonLoader.tsx
+++ b/src/MoonLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, parseLengthAndUnit, cssValue } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps, CalcFunction } from "./interfaces";
 
 type BallStyleFunction = (size: number) => PrecompiledCss;
@@ -17,41 +17,42 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
 
   public moonSize: CalcFunction<number> = (): number => {
     const { size } = this.props;
+    let { value } = parseLengthAndUnit(size!);
 
-    return size! / 7;
+    return value / 7;
   };
 
   public ballStyle: BallStyleFunction = (size: number): PrecompiledCss => {
-    const { sizeUnit } = this.props;
-
     return css`
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size)};
+      height: ${cssValue(size)};
       border-radius: 100%;
     `;
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: relative;
-      width: ${`${size! + this.moonSize() * 2}${sizeUnit}`};
-      height: ${`${size! + this.moonSize() * 2}${sizeUnit}`};
+      width: ${`${value + this.moonSize() * 2}${unit}`};
+      height: ${`${value + this.moonSize() * 2}${unit}`};
       animation: ${moon} 0.6s 0s infinite linear;
       animation-fill-mode: forwards;
     `;
   };
 
   public ball: CalcFunction<PrecompiledCss> = (): PrecompiledCss => {
-    const { color, size, sizeUnit } = this.props;
+    const { color, size } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       ${this.ballStyle(this.moonSize())};
       background-color: ${color};
       opacity: 0.8;
       position: absolute;
-      top: ${`${size! / 2 - this.moonSize() / 2}${sizeUnit}`};
+      top: ${`${value / 2 - this.moonSize() / 2}${unit}`};
       animation: ${moon} 0.6s 0s infinite linear;
       animation-fill-mode: forwards;
     `;
@@ -59,9 +60,10 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
 
   public circle: CalcFunction<PrecompiledCss> = (): PrecompiledCss => {
     const { size, color } = this.props;
+    let { value } = parseLengthAndUnit(size!);
 
     return css`
-      ${this.ballStyle(size!)};
+      ${this.ballStyle(value)};
       border: ${this.moonSize()}px solid ${color};
       opacity: 0.1;
     `;

--- a/src/PacmanLoader.tsx
+++ b/src/PacmanLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, parseLengthAndUnit, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -27,46 +27,48 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(25);
 
   public ball: CalcFunction<Keyframes> = (): Keyframes => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return keyframes`
       75% {opacity: 0.7}
-      100% {transform: translate(${`${-4 * size!}${sizeUnit}`}, ${`${-size! / 4}${sizeUnit}`})}
+      100% {transform: translate(${`${-4 * value}${unit}`}, ${`${-value / 4}${unit}`})}
     `;
   };
 
   public ballStyle: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, margin, size, sizeUnit } = this.props;
+    const { color, margin, size } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
-      width: ${`${size! / 3}${sizeUnit}`};
-      height: ${`${size! / 3}${sizeUnit}`};
+      width: ${`${value / 3}${unit}`};
+      height: ${`${value / 3}${unit}`};
       background-color: ${color};
-      margin: ${margin};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
-      transform: translate(0, ${`${-size! / 4}${sizeUnit}`});
+      transform: translate(0, ${`${-value / 4}${unit}`});
       position: absolute;
-      top: ${`${size}${sizeUnit}`};
-      left: ${`${size! * 4}${sizeUnit}`};
+      top: ${`${value}${unit}`};
+      left: ${`${value * 4}${unit}`};
       animation: ${this.ball()} 1s ${i * 0.25}s infinite linear;
       animation-fill-mode: both;
     `;
   };
 
   public s1: CalcFunction<string> = (): string => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
-    return `${size}${sizeUnit} solid transparent`;
+    return `${cssValue(size!)} solid transparent`;
   };
 
   public s2: CalcFunction<string> = (): string => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
 
-    return `${size}${sizeUnit} solid ${color}`;
+    return `${cssValue(size!)} solid ${color}`;
   };
 
   public pacmanStyle: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     const s1: string = this.s1();
     const s2: string = this.s2();
@@ -78,7 +80,7 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
       border-top: ${i === 0 ? s1 : s2};
       border-left: ${s2};
       border-bottom: ${i === 0 ? s2 : s1};
-      border-radius: ${`${size}${sizeUnit}`};
+      border-radius: ${cssValue(size!)};
       position: absolute;
       animation: ${pacman[i]} 0.8s infinite ease-in-out;
       animation-fill-mode: both;
@@ -86,13 +88,13 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
       position: relative;
       font-size: 0;
-      height: ${`${size}${sizeUnit}`};
-      width: ${`${size}${sizeUnit}`};
+      height: ${cssValue(size!)};
+      width: ${cssValue(size!)};
     `;
   };
 

--- a/src/PropagateLoader.tsx
+++ b/src/PropagateLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, parseLengthAndUnit } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -55,13 +55,14 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(15);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: absolute;
-      font-size: ${`${size! / 3}${sizeUnit}`};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      font-size: ${`${value / 3}${unit}`};
+      width: ${`${value}${unit}`};
+      height: ${`${value}${unit}`};
       background: ${color};
       border-radius: 50%;
       animation: ${propagate[i]} 1.5s infinite;

--- a/src/PulseLoader.tsx
+++ b/src/PulseLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue } from "./helpers";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
 
 const pulse: Keyframes = keyframes`
@@ -16,13 +16,13 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       display: inline-block;
       animation: ${pulse} 0.75s ${i * 0.12}s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);

--- a/src/RingLoader.tsx
+++ b/src/RingLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, parseLengthAndUnit, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -25,15 +25,16 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(60);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
+    let { value, unit } = parseLengthAndUnit(size!);
 
     return css`
       position: absolute;
       top: 0;
       left: 0;
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      border: ${`${size! / 10}${sizeUnit}`} solid ${color};
+      width: ${`${value}${unit}`};
+      height: ${`${value}${unit}`};
+      border: ${`${value! / 10}${unit}`} solid ${color};
       opacity: 0.4;
       border-radius: 100%;
       animation-fill-mode: forwards;
@@ -43,11 +44,11 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public wrapper: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit } = this.props;
+    const { size } = this.props;
 
     return css`
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
       position: relative;
     `;
   };

--- a/src/RiseLoader.tsx
+++ b/src/RiseLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue } from "./helpers";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
 
 const riseAmount: number = 30;
@@ -28,13 +28,13 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${`${margin}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       display: inline-block;
       animation: ${i % 2 === 0 ? even : odd} 1s 0s infinite cubic-bezier(0.15, 0.46, 0.9, 0.6);

--- a/src/RotateLoader.tsx
+++ b/src/RotateLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeMarginDefaults } from "./helpers";
+import { sizeMarginDefaults, cssValue } from "./helpers";
 import {
   StyleFunction,
   PrecompiledCss,
@@ -28,13 +28,13 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   `;
 
   public ball: StyleFunction = (): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
     `;
   };

--- a/src/ScaleLoader.tsx
+++ b/src/ScaleLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { heightWidthRadiusDefaults } from "./helpers";
+import { heightWidthRadiusDefaults, cssValue } from "./helpers";
 import { PrecompiledCss, LoaderHeightWidthRadiusProps, StyleFunctionWithIndex } from "./interfaces";
 
 const scale: Keyframes = keyframes`
@@ -16,14 +16,14 @@ class Loader extends React.PureComponent<LoaderHeightWidthRadiusProps> {
   public static defaultProps: LoaderHeightWidthRadiusProps = heightWidthRadiusDefaults(35, 4, 2);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, width, height, margin, radius, widthUnit, heightUnit, radiusUnit } = this.props;
+    const { color, width, height, margin, radius } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${width}${widthUnit}`};
-      height: ${`${height}${heightUnit}`};
-      margin: ${margin};
-      border-radius: ${`${radius}${radiusUnit}`};
+      width: ${cssValue(width!)};
+      height: ${cssValue(height!)};
+      margin: ${cssValue(margin!)};
+      border-radius: ${cssValue(radius!)};
       display: inline-block;
       animation: ${scale} 1s ${i * 0.1}s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);
       animation-fill-mode: both;

--- a/src/SkewLoader.tsx
+++ b/src/SkewLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, cssValue } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const skew: Keyframes = keyframes`
@@ -17,14 +17,14 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(20);
 
   public style: StyleFunction = (): PrecompiledCss => {
-    const { size, sizeUnit, color } = this.props;
+    const { size, color } = this.props;
 
     return css`
       width: 0;
       height: 0;
-      border-left: ${`${size}${sizeUnit}`} solid transparent;
-      border-right: ${`${size}${sizeUnit}`} solid transparent;
-      border-bottom: ${`${size}${sizeUnit}`} solid ${color};
+      border-left: ${cssValue(size!)} solid transparent;
+      border-right: ${cssValue(size!)} solid transparent;
+      border-bottom: ${cssValue(size!)} solid ${color};
       display: inline-block;
       animation: ${skew} 3s 0s infinite cubic-bezier(0.09, 0.57, 0.49, 0.9);
       animation-fill-mode: both;

--- a/src/SquareLoader.tsx
+++ b/src/SquareLoader.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { keyframes, css, jsx } from "@emotion/core";
 import { Keyframes } from "@emotion/serialize";
 
-import { sizeDefaults } from "./helpers";
+import { sizeDefaults, cssValue } from "./helpers";
 import { StyleFunction, PrecompiledCss, LoaderSizeProps } from "./interfaces";
 
 const square: Keyframes = keyframes`
@@ -17,12 +17,12 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   public static defaultProps: LoaderSizeProps = sizeDefaults(50);
 
   public style: StyleFunction = (): PrecompiledCss => {
-    const { color, size, sizeUnit } = this.props;
+    const { color, size } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
       display: inline-block;
       animation: ${square} 3s 0s infinite cubic-bezier(0.09, 0.57, 0.49, 0.9);
       animation-fill-mode: both;

--- a/src/SyncLoader.tsx
+++ b/src/SyncLoader.tsx
@@ -5,6 +5,7 @@ import { Keyframes } from "@emotion/serialize";
 
 import { sizeMarginDefaults } from "./helpers/proptypes";
 import { PrecompiledCss, LoaderSizeMarginProps, StyleFunctionWithIndex } from "./interfaces";
+import { cssValue } from "./helpers";
 
 const sync: Keyframes = keyframes`
   33% {transform: translateY(10px)}
@@ -16,13 +17,13 @@ class Loader extends React.PureComponent<LoaderSizeMarginProps> {
   public static defaultProps: LoaderSizeMarginProps = sizeMarginDefaults(15);
 
   public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
-    const { color, size, sizeUnit, margin } = this.props;
+    const { color, size, margin } = this.props;
 
     return css`
       background-color: ${color};
-      width: ${`${size}${sizeUnit}`};
-      height: ${`${size}${sizeUnit}`};
-      margin: ${margin};
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+      margin: ${cssValue(margin!)};
       border-radius: 100%;
       display: inline-block;
       animation: ${sync} 0.6s ${i * 0.07}s infinite ease-in-out;

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -1,74 +1,54 @@
-/*
- * List of string constants to represent different props
- */
-const LOADING: string = "loading";
-const COLOR: string = "color";
-const CSS: string = "css";
-const SIZE: string = "size";
-const SIZE_UNIT: string = "sizeUnit";
-const WIDTH: string = "width";
-const WIDTH_UNIT: string = "widthUnit";
-const HEIGHT: string = "height";
-const HEIGHT_UNIT: string = "heightUnit";
-const RADIUS: string = "radius";
-const RADIUS_UNIT: string = "radiusUnit";
-const MARGIN: string = "margin";
+import {
+  LoaderHeightWidthProps,
+  LoaderSizeProps,
+  PrecompiledCss,
+  LoaderSizeMarginProps,
+  LoaderHeightWidthRadiusProps
+} from "../interfaces";
 
 /*
  * DefaultProps object for different loaders
  */
 
-export interface DefaultProps {
-  [key: string]: boolean | string | {} | number;
+interface CommonDefaults {
+  loading: boolean;
+  color: string;
+  css: string | PrecompiledCss;
 }
 
-type HeightWidthFunction = (height: number, width: number) => DefaultProps;
-type HeightWidthRadiusFunction = (height: number, width: number, radius?: number) => DefaultProps;
-type SizeFunction = (size: number) => DefaultProps;
-
-const commonValues: DefaultProps = {
-  [LOADING]: true,
-  [COLOR]: "#000000",
-  [CSS]: {}
+const commonValues: CommonDefaults = {
+  loading: true,
+  color: "#000000",
+  css: ""
 };
 
-const heightWidthValues: HeightWidthFunction = (height: number, width: number): DefaultProps => ({
-  [HEIGHT]: height,
-  [HEIGHT_UNIT]: "px",
-  [WIDTH]: width,
-  [WIDTH_UNIT]: "px"
-});
+export function sizeDefaults(sizeValue: number): Required<LoaderSizeProps> {
+  return Object.assign({}, commonValues, { size: sizeValue });
+}
 
-const sizeValues: SizeFunction = (sizeValue: number): DefaultProps => ({
-  [SIZE]: sizeValue,
-  [SIZE_UNIT]: "px"
-});
-
-export const sizeDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
-  return Object.assign({}, commonValues, sizeValues(sizeValue));
-};
-
-export const sizeMarginDefaults: SizeFunction = (sizeValue: number): DefaultProps => {
+export function sizeMarginDefaults(sizeValue: number): Required<LoaderSizeMarginProps> {
   return Object.assign({}, sizeDefaults(sizeValue), {
-    [MARGIN]: "2px"
+    margin: "2px"
   });
-};
+}
 
-export const heightWidthDefaults: HeightWidthFunction = (
+export function heightWidthDefaults(
   height: number,
   width: number
-): DefaultProps => {
-  return Object.assign({}, commonValues, heightWidthValues(height, width));
-};
+): Required<LoaderHeightWidthProps> {
+  return Object.assign({}, commonValues, {
+    height,
+    width
+  });
+}
 
-export const heightWidthRadiusDefaults: HeightWidthRadiusFunction = (
+export function heightWidthRadiusDefaults(
   height: number,
   width: number,
   radius: number = 2
-): DefaultProps => {
+): Required<LoaderHeightWidthRadiusProps> {
   return Object.assign({}, heightWidthDefaults(height, width), {
-    [RADIUS]: radius,
-    [RADIUS_UNIT]: "px",
-    [MARGIN]: "2px"
+    radius,
+    margin: "2px"
   });
-};
+}

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -28,7 +28,7 @@ export function sizeDefaults(sizeValue: number): Required<LoaderSizeProps> {
 
 export function sizeMarginDefaults(sizeValue: number): Required<LoaderSizeMarginProps> {
   return Object.assign({}, sizeDefaults(sizeValue), {
-    margin: "2px"
+    margin: 2
   });
 }
 
@@ -49,6 +49,6 @@ export function heightWidthRadiusDefaults(
 ): Required<LoaderHeightWidthRadiusProps> {
   return Object.assign({}, heightWidthDefaults(height, width), {
     radius,
-    margin: "2px"
+    margin: 2
   });
 }

--- a/src/helpers/unitConverter.ts
+++ b/src/helpers/unitConverter.ts
@@ -27,7 +27,7 @@ const cssUnit: { [unit: string]: boolean } = {
  * @param {(number | string)} size
  * @return {LengthObject} LengthObject
  */
-export function unitConverter(size: number | string): LengthObject {
+export function parseLengthAndUnit(size: number | string): LengthObject {
   if (typeof size === "number") {
     return {
       value: size,
@@ -57,4 +57,16 @@ export function unitConverter(size: number | string): LengthObject {
     value,
     unit: "px"
   };
+}
+
+/**
+ * Take value as an input and return valid css value
+ *
+ * @param {(number | string)} value
+ * @return {string} valid css value
+ */
+export function cssValue(value: number | string): string {
+  let lengthWithunit: LengthObject = parseLengthAndUnit(value!);
+
+  return `${lengthWithunit.value}${lengthWithunit.unit}`;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,24 +20,22 @@ interface CommonProps {
   css?: string | PrecompiledCss;
 }
 
+type LengthType = number | string;
+
 export interface LoaderHeightWidthProps extends CommonProps {
-  height?: number;
-  heightUnit?: string;
-  width?: number;
-  widthUnit?: string;
+  height?: LengthType;
+  width?: LengthType;
 }
 
 export interface LoaderSizeProps extends CommonProps {
-  size?: number;
-  sizeUnit?: string;
+  size?: LengthType;
 }
 
 export interface LoaderSizeMarginProps extends LoaderSizeProps {
-  margin?: string;
+  margin?: LengthType;
 }
 
 export interface LoaderHeightWidthRadiusProps extends LoaderHeightWidthProps {
-  margin?: string;
-  radius?: number;
-  radiusUnit?: string;
+  margin?: LengthType;
+  radius?: LengthType;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -67,7 +67,8 @@
       "variable-declaration",
       "member-variable-declaration"
     ],
-    "semicolon": false
+    "semicolon": false,
+    "object-literal-key-quotes": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
- deprecate sizeUnit, heightUnit, widthUnit, and radiusUnit from proptypes and interfaces. The `size`, `height`, `width`, `radius`, and `margin` prop all accept number or string and will add `px` as a default, keep the original input as is if string with valid unit, or default to px with a console warning. 
- changed `css` prop default to `""` to fix typescript error for `{}` is not `PrecompiledCss`
- updated all tests to include test cases for number, string w/ valid unit, string w/ invalid unit