### PR TITLE
Make the box-sizing explicit on the MoonLoader circle

### DIFF
--- a/src/MoonLoader.tsx
+++ b/src/MoonLoader.tsx
@@ -66,6 +66,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
       ${this.ballStyle(value)};
       border: ${this.moonSize()}px solid ${color};
       opacity: 0.1;
+      box-sizing: content-box;
     `;
   };
 


### PR DESCRIPTION
Recent versions of Tailwind CSS force everything to `box-sizing: border-box;`
(see https://github.com/tailwindcss/tailwindcss/pull/1111 )
Tailwind isn't the only thing out there using that hack, so this is sure to be a wider-ranging problem.
The result of using Tailwind & react-spinners in the same project without this change is that the spinner circle wobbles around.