### PR TITLE
New Puff Loader with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The table below has the default values for each loader.
 |        MoonLoader | `60` |        |       |        |  `2`   |
 |      PacmanLoader | `25` |        |       |        |  `2`   |
 |   PropagateLoader | `15` |        |       |        |
+|        PuffLoader | `60` |        |       |        |
 |       PulseLoader | `15` |        |       |        |  `2`   |
 |        RingLoader | `60` |        |       |        |  `2`   |
 |        RiseLoader | `15` |        |       |        |  `2`   |

--- a/__tests__/PuffLoader-tests.tsx
+++ b/__tests__/PuffLoader-tests.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { mount, ReactWrapper } from "enzyme";
+import { matchers } from "jest-emotion";
+expect.extend(matchers);
+
+import PuffLoader from "../src/PuffLoader";
+import { LoaderSizeProps } from "../src/interfaces";
+import { sizeDefaults } from "../src/helpers";
+
+describe("PuffLoader", () => {
+  let loader: ReactWrapper<LoaderSizeProps, null, PuffLoader>;
+  let props: LoaderSizeProps;
+  let defaultColor: string = "#000000";
+  let defaultSize: number = 60;
+  let defaultUnit: string = "px";
+
+  it("should match snapshot", () => {
+    loader = mount(<PuffLoader />);
+    expect(loader).toMatchSnapshot();
+  });
+
+  it("should contain default props if no props are passed", () => {
+    props = loader.props();
+    expect(props).toEqual(sizeDefaults(defaultSize));
+  });
+
+  it("should contain styles created using default props", () => {
+    expect(loader).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+    expect(loader).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+    expect(loader.find("div div")).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+    expect(loader.find("div div")).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+    expect(loader.find("div div")).toHaveStyleRule("border", `thick solid ${defaultColor}`);
+  });
+
+  it("should render null if loading prop is set as false", () => {
+    loader = mount(<PuffLoader loading={false} />);
+    expect(loader.isEmptyRender()).toBe(true);
+  });
+
+  it("should render the correct color based on prop", () => {
+    let color: string = "#e2e2e2";
+    loader = mount(<PuffLoader color={color} />);
+    expect(loader.find("div div")).not.toHaveStyleRule("border", `thick solid ${defaultColor}`);
+    expect(loader.find("div div")).toHaveStyleRule("border", `thick solid ${color}`);
+  });
+
+  describe("size prop", () => {
+    it("should render the size with px unit when size is a number", () => {
+      let size: number = 18;
+      loader = mount(<PuffLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}${defaultUnit}`);
+    });
+
+    it("should render the size as is when size is a string with valid css unit", () => {
+      let size: string = "18px";
+      loader = mount(<PuffLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${size}`);
+      expect(loader).toHaveStyleRule("width", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${size}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${size}`);
+    });
+
+    it("should render the size with default unit of px when the unit is incorrect", () => {
+      let length: number = 18;
+      let unit: string = "ad";
+      let size: string = `${length}${unit}`;
+      loader = mount(<PuffLoader size={size} />);
+      expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("div div")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+
+      expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("height", `${length}${defaultUnit}`);
+      expect(loader.find("div div")).toHaveStyleRule("width", `${length}${defaultUnit}`);
+    });
+  });
+
+  it("should render the css override based on props", () => {
+    loader = mount(<PuffLoader css={"position: absolute; overflow: scroll;"} />);
+    expect(loader).not.toHaveStyleRule("position", "relative");
+    expect(loader).toHaveStyleRule("position", "absolute");
+    expect(loader).toHaveStyleRule("overflow", "scroll");
+  });
+});

--- a/src/PuffLoader.tsx
+++ b/src/PuffLoader.tsx
@@ -1,0 +1,70 @@
+/** @jsx jsx */
+import * as React from "react";
+import { keyframes, css, jsx } from "@emotion/core";
+import { Keyframes } from "@emotion/serialize";
+
+import { sizeDefaults, cssValue } from "./helpers";
+import {
+  StyleFunction,
+  PrecompiledCss,
+  LoaderSizeProps,
+  StyleFunctionWithIndex
+} from "./interfaces";
+
+const puff: Keyframes[] = [keyframes`
+  0%  {transform: scale(0)}
+  100% {transform: scale(1.0)}
+`,
+ keyframes`
+  0%  {opacity: 1}
+  100% {opacity: 0}
+`];
+
+
+class Loader extends React.PureComponent<LoaderSizeProps> {
+  public static defaultProps: Required<LoaderSizeProps> = sizeDefaults(60);
+
+  public style: StyleFunctionWithIndex = (i: number): PrecompiledCss => {
+    const { color, size } = this.props;
+
+    return css`
+      position: absolute;
+      height: ${cssValue(size!)};
+      width: ${cssValue(size!)};
+      border: thick solid ${color};
+      border-radius: 50%;
+      opacity: 1;
+      top: 0;
+      left: 0;
+      animation-fill-mode: both;
+      animation: ${puff[0]}, ${puff[1]};
+      animation-duration: 2s;
+      animation-iteration-count: infinite;
+      animation-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1), cubic-bezier(0.3, 0.61, 0.355, 1);
+      animation-delay: ${i === 1 ? "-1s" : "0s"};
+    `;
+  };
+
+  public wrapper: StyleFunction = (): PrecompiledCss => {
+    const { size } = this.props;
+
+    return css`
+      position: relative;
+      width: ${cssValue(size!)};
+      height: ${cssValue(size!)};
+    `;
+  };
+
+  public render(): JSX.Element | null {
+    const { loading, css } = this.props;
+
+    return loading ? (
+      <div css={[this.wrapper(), css]}>
+        <div css={this.style(1)} />
+        <div css={this.style(2)} />
+      </div>
+    ) : null;
+  }
+}
+
+export default Loader;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import MoonLoaderComponent from "./MoonLoader";
 import PacmanLoaderComponent from "./PacmanLoader";
 import PropagateLoaderComponent from "./PropagateLoader";
 import PulseLoaderComponent from "./PulseLoader";
+import PuffLoaderComponent from "./PuffLoader";
 import RingLoaderComponent from "./RingLoader";
 import RiseLoaderComponent from "./RiseLoader";
 import RotateLoaderComponent from "./RotateLoader";
@@ -43,6 +44,7 @@ export const MoonLoader: React.ComponentClass<LoaderSizeProps> = MoonLoaderCompo
 export const PacmanLoader: React.ComponentClass<LoaderSizeMarginProps> = PacmanLoaderComponent;
 export const PropagateLoader: React.ComponentClass<LoaderSizeProps> = PropagateLoaderComponent;
 export const PulseLoader: React.ComponentClass<LoaderSizeMarginProps> = PulseLoaderComponent;
+export const PuffLoader: React.ComponentClass<LoaderSizeProps> = PuffLoaderComponent;
 export const RingLoader: React.ComponentClass<LoaderSizeProps> = RingLoaderComponent;
 export const RiseLoader: React.ComponentClass<LoaderSizeMarginProps> = RiseLoaderComponent;
 export const RotateLoader: React.ComponentClass<LoaderSizeMarginProps> = RotateLoaderComponent;


### PR DESCRIPTION
Have added a new Puff Loader with a respective test file. The puff loader is taken from [http://samherbert.net/svg-loaders/](http://samherbert.net/svg-loaders/)(2nd row, 4th column http://samherbert.net/svg-loaders/svg-loaders/puff.svg) referenced in the feature request #43 . Please review and suggest any changes.
Thank you.

