### PR TITLE
Properly override module in tsconfig build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.10.2
+
+- **bugfix**: the tsconfig compiler option was not overriding properly, so the outputted files are es2015 (with import syntax) vs commonjs (with require syntax. This could cause similar issues like [#74](https://github.com/davidhu2000/react-spinners/issues/74).
+
 ## 0.10.1
 
 - Update README using react hooks. Move react class example under a summary tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 0.10.1
 
+**Note: this release has a critical issue and was deprecated. Please update to 0.10.2 or higher.**
+
 - Update README using react hooks. Move react class example under a summary tag.
 
 ## 0.10.0
+
+**Note: this release has a critical issue and was deprecated. Please update to 0.10.2 or higher.**
 
 - update `div` to `span` to fix `<div> cannot appear as a descendant of <p>` per [#159](https://github.com/davidhu2000/react-spinners/issues/159). [PR #325](https://github.com/davidhu2000/react-spinners/pull/325)
 - Using [lodash-es](https://github.com/lodash/lodash/blob/4.17.20-es/package.json#L10-L14) as a reference, added `type: module` to `package.json` as an attempt to implement tree shaking via [PR #327](https://github.com/davidhu2000/react-spinners/pull/327).

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
   "exclude": ["docs/*", "webpack.config.*", "*.js", "__tests__", "examples"]
 }


### PR DESCRIPTION
the compiler option was not overriding properly, so the outputted files are es2015 (with `import` syntax) vs commonjs (with `require` syntax. This could cause similar issues like #74. 

Now the tsconfig module field will properly override during build phase. 