### PR TITLE
feat: optional animation delay in PuffLoader

### DIFF
--- a/__tests__/PuffLoader-tests.tsx
+++ b/__tests__/PuffLoader-tests.tsx
@@ -44,13 +44,23 @@ describe("PuffLoader", () => {
     expect(loader.find("span span")).toHaveStyleRule("border", `thick solid ${color}`);
   });
 
+  it("should render the correct animation delay based on prop", () => {
+    const animationDelay = -0.3;
+    loader = mount(<PuffLoader animationDelay={animationDelay} />);
+    expect(loader.find("span span").at(0)).toHaveStyleRule("animation-delay", "-1.3s");
+    expect(loader.find("span span").at(1)).toHaveStyleRule("animation-delay", "-0.3s");
+  });
+
   describe("size prop", () => {
     it("should render the size with px unit when size is a number", () => {
       const size = 18;
       loader = mount(<PuffLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
@@ -64,7 +74,10 @@ describe("PuffLoader", () => {
       loader = mount(<PuffLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${size}`);
@@ -80,7 +93,10 @@ describe("PuffLoader", () => {
       loader = mount(<PuffLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);

--- a/__tests__/__snapshots__/BarLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BarLoader-tests.tsx.snap
@@ -75,6 +75,7 @@ exports[`BarLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   height={4}

--- a/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BeatLoader-tests.tsx.snap
@@ -60,6 +60,7 @@ exports[`BeatLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/BounceLoader-tests.tsx.snap
@@ -66,6 +66,7 @@ exports[`BounceLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/CircleLoader-tests.tsx.snap
@@ -198,6 +198,7 @@ exports[`CircleLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClimbingBoxLoader-tests.tsx.snap
@@ -117,6 +117,7 @@ exports[`ClimbingBoxLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClipLoader-tests.tsx.snap
@@ -37,6 +37,7 @@ exports[`ClipLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/ClockLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ClockLoader-tests.tsx.snap
@@ -58,6 +58,7 @@ exports[`ClockLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/DotLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/DotLoader-tests.tsx.snap
@@ -76,6 +76,7 @@ exports[`DotLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/FadeLoader-tests.tsx.snap
@@ -245,6 +245,7 @@ exports[`FadeLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   height={15}

--- a/__tests__/__snapshots__/GridLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/GridLoader-tests.tsx.snap
@@ -42,6 +42,7 @@ exports[`GridLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/HashLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/HashLoader-tests.tsx.snap
@@ -89,6 +89,7 @@ exports[`HashLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/MoonLoader-tests.tsx.snap
@@ -51,6 +51,7 @@ exports[`MoonLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PacmanLoader-tests.tsx.snap
@@ -187,6 +187,7 @@ exports[`PacmanLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PropagateLoader-tests.tsx.snap
@@ -228,6 +228,7 @@ exports[`PropagateLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/PuffLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/PuffLoader-tests.tsx.snap
@@ -102,6 +102,7 @@ exports[`PuffLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/PulseLoader-test.tsx.snap
+++ b/__tests__/__snapshots__/PulseLoader-test.tsx.snap
@@ -110,6 +110,7 @@ exports[`PulseLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/RingLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RingLoader-tests.tsx.snap
@@ -74,6 +74,7 @@ exports[`RingLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RiseLoader-tests.tsx.snap
@@ -92,6 +92,7 @@ exports[`RiseLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/RotateLoader-tests.tsx.snap
@@ -57,6 +57,7 @@ exports[`RotateLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/ScaleLoader-tests.tsx.snap
@@ -167,6 +167,7 @@ exports[`ScaleLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   height={35}

--- a/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SkewLoader-tests.tsx.snap
@@ -41,6 +41,7 @@ exports[`SkewLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SquareLoader-tests.tsx.snap
@@ -39,6 +39,7 @@ exports[`SquareLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
+++ b/__tests__/__snapshots__/SyncLoader-tests.tsx.snap
@@ -101,6 +101,7 @@ exports[`SyncLoader should match snapshot 1`] = `
 }
 
 <Loader
+  animationDelay={0}
   color="#000000"
   css=""
   loading={true}

--- a/src/PuffLoader.tsx
+++ b/src/PuffLoader.tsx
@@ -24,7 +24,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
   };
 
   public style = (i: number): SerializedStyles => {
-    const { color } = this.props;
+    const { animationDelay = 0, color } = this.props;
 
     return css`
       position: absolute;
@@ -41,7 +41,7 @@ class Loader extends React.PureComponent<LoaderSizeProps> {
       animation-iteration-count: infinite;
       animation-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1),
         cubic-bezier(0.3, 0.61, 0.355, 1);
-      animation-delay: ${i === 1 ? "-1s" : "0s"};
+      animation-delay: ${(i === 1 ? -1 : 0) + animationDelay}s;
     `;
   };
 

--- a/src/helpers/proptypes.ts
+++ b/src/helpers/proptypes.ts
@@ -23,7 +23,7 @@ const commonValues: CommonDefaults = {
 };
 
 export function sizeDefaults(sizeValue: number): Required<LoaderSizeProps> {
-  return Object.assign({}, commonValues, { size: sizeValue });
+  return Object.assign({}, commonValues, { size: sizeValue, animationDelay: 0 });
 }
 
 export function sizeMarginDefaults(sizeValue: number): Required<LoaderSizeMarginProps> {
@@ -38,7 +38,8 @@ export function heightWidthDefaults(
 ): Required<LoaderHeightWidthProps> {
   return Object.assign({}, commonValues, {
     height,
-    width
+    width,
+    animationDelay: 0
   });
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ interface CommonProps {
   color?: string;
   loading?: boolean;
   css?: string | SerializedStyles;
+  animationDelay?: number;
 }
 
 export type LengthType = number | string;


### PR DESCRIPTION
This is a simple feature to delay the animation on PuffLoader. I suppose it could be extended to other loaders too.

The idea is that if you have multiple things loading, and you're rendering the loader from multiple places, you want to keep track of which stage of the animation the loader is in - otherwise, the animation will reset back to the beginning resulting in a jerky animation.

There is an article detailing the application of this here: https://www.selbekk.io/blog/2019/08/how-to-stop-your-spinner-from-jumping-in-react/