### PR TITLE
Refactor common specs to a helper

### DIFF
--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -140,4 +140,12 @@ describe("BarLoader", () => {
       animationSpeedSpec(Infinity);
     });
   });
+
+  it("should render the css override based on props", () => {
+    const loader = mount(<BarLoader css={"position: absolute; overflow: scroll;"} />);
+    expect(loader).not.toHaveStyleRule("position", "relative");
+    expect(loader).toHaveStyleRule("position", "absolute");
+    expect(loader).not.toHaveStyleRule("overflow", "hidden");
+    expect(loader).toHaveStyleRule("overflow", "scroll");
+  });
 });

--- a/__tests__/BarLoader-tests.tsx
+++ b/__tests__/BarLoader-tests.tsx
@@ -1,31 +1,22 @@
 import * as React from "react";
-import { mount, ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import { matchers } from "@emotion/jest";
 expect.extend(matchers);
 
 import BarLoader from "../src/BarLoader";
-import { LoaderHeightWidthProps } from "../src/interfaces";
+import { commonSpecs } from "./sharedSpecs/commonSpecs";
 import { heightWidthDefaults } from "../src/helpers";
 
 describe("BarLoader", () => {
-  let loader: ReactWrapper<LoaderHeightWidthProps, null, BarLoader>;
-  let props: LoaderHeightWidthProps;
   const defaultColor = "#000000";
   const defaultHeight = 4;
   const defaultWidth = 100;
   const defaultUnit = "px";
 
-  it("should match snapshot", () => {
-    loader = mount(<BarLoader />);
-    expect(loader).toMatchSnapshot();
-  });
-
-  it("should contain default props if no props are passed", () => {
-    props = loader.props();
-    expect(props).toEqual(heightWidthDefaults(defaultHeight, defaultWidth));
-  });
+  commonSpecs(BarLoader, heightWidthDefaults(defaultHeight, defaultWidth));
 
   it("should contain styles created using default props", () => {
+    const loader = mount(<BarLoader />);
     expect(loader).toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
     expect(loader).toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
     expect(loader).toHaveStyleRule("background-color", "rgba(0, 0, 0, 0.2)");
@@ -33,14 +24,9 @@ describe("BarLoader", () => {
     expect(loader.find("span span")).toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
   });
 
-  it("should render null if loading prop is set as false", () => {
-    loader = mount(<BarLoader loading={false} />);
-    expect(loader.isEmptyRender()).toBe(true);
-  });
-
   it("should render the correct color based on passed in prop", () => {
     const color = "#e2e2e2";
-    loader = mount(<BarLoader color={color} />);
+    const loader = mount(<BarLoader color={color} />);
     expect(loader).not.toHaveStyleRule("background-color", "rgba(0, 0, 0, 0.2)");
     expect(loader).toHaveStyleRule("background-color", "rgba(226, 226, 226, 0.2)");
     expect(loader.find("span span")).toHaveStyleRule("background-color", color);
@@ -49,7 +35,7 @@ describe("BarLoader", () => {
   describe("height prop", () => {
     it("should render the height with px unit when size is a number", () => {
       const height = 10;
-      loader = mount(<BarLoader height={height} />);
+      const loader = mount(<BarLoader height={height} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
       expect(loader).toHaveStyleRule("height", `${height}${defaultUnit}`);
       expect(loader.find("span span")).not.toHaveStyleRule(
@@ -61,7 +47,7 @@ describe("BarLoader", () => {
 
     it("should render the height as is when height is a string with valid css unit", () => {
       const height = "18%";
-      loader = mount(<BarLoader height={height} />);
+      const loader = mount(<BarLoader height={height} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
       expect(loader).toHaveStyleRule("height", `${height}`);
       expect(loader.find("span span")).not.toHaveStyleRule(
@@ -75,7 +61,7 @@ describe("BarLoader", () => {
       const length = 18;
       const unit = "ad";
       const height = `${length}${unit}`;
-      loader = mount(<BarLoader height={height} />);
+      const loader = mount(<BarLoader height={height} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultHeight}${defaultUnit}`);
       expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
       expect(loader.find("span span")).not.toHaveStyleRule(
@@ -89,14 +75,14 @@ describe("BarLoader", () => {
   describe("width prop", () => {
     it("should render the width with px unit when size is a number", () => {
       const width = 10;
-      loader = mount(<BarLoader width={10} />);
+      const loader = mount(<BarLoader width={10} />);
       expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
       expect(loader).toHaveStyleRule("width", `${width}${defaultUnit}`);
     });
 
     it("should render the height as is when height is a string with valid css unit", () => {
       const width = "18%";
-      loader = mount(<BarLoader width={width} />);
+      const loader = mount(<BarLoader width={width} />);
       expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
       expect(loader).toHaveStyleRule("width", `${width}`);
     });
@@ -105,7 +91,7 @@ describe("BarLoader", () => {
       const length = 18;
       const unit = "ad";
       const width = `${length}${unit}`;
-      loader = mount(<BarLoader width={width} />);
+      const loader = mount(<BarLoader width={width} />);
       expect(loader).not.toHaveStyleRule("width", `${defaultWidth}${defaultUnit}`);
       expect(loader).toHaveStyleRule("width", `${length}${defaultUnit}`);
     });
@@ -114,6 +100,7 @@ describe("BarLoader", () => {
   describe("speedMultipler prop", () => {
     const defaultSpeed = 2.1;
     const defaultDelay = 1.15;
+    let loader = mount(<BarLoader />);
 
     const animationSpeedSpec = (multiplier: number) => {
       expect(loader.find("span span").at(0)).toHaveStyleRule(
@@ -132,7 +119,6 @@ describe("BarLoader", () => {
     };
 
     it("should use default speed and delay if speedMultipler is not passed in", () => {
-      loader = mount(<BarLoader />);
       animationSpeedSpec(1);
     });
 
@@ -153,13 +139,5 @@ describe("BarLoader", () => {
       loader = mount(<BarLoader speedMultiplier={speedMultiplier} />);
       animationSpeedSpec(Infinity);
     });
-  });
-
-  it("should render the css override based on props", () => {
-    loader = mount(<BarLoader css={"position: absolute; overflow: scroll;"} />);
-    expect(loader).not.toHaveStyleRule("position", "relative");
-    expect(loader).toHaveStyleRule("position", "absolute");
-    expect(loader).not.toHaveStyleRule("overflow", "hidden");
-    expect(loader).toHaveStyleRule("overflow", "scroll");
   });
 });

--- a/__tests__/BeatLoader-tests.tsx
+++ b/__tests__/BeatLoader-tests.tsx
@@ -1,45 +1,30 @@
 import * as React from "react";
-import { mount, ReactWrapper } from "enzyme";
-import { matchers } from '@emotion/jest';
+import { mount } from "enzyme";
+import { matchers } from "@emotion/jest";
 expect.extend(matchers);
 
 import BeatLoader from "../src/BeatLoader";
-import { LoaderSizeMarginProps } from "../src/interfaces";
 import { sizeMarginDefaults } from "../src/helpers";
+import { commonSpecs } from "./sharedSpecs/commonSpecs";
 
 describe("BeatLoader", () => {
-  let loader: ReactWrapper<LoaderSizeMarginProps, null, BeatLoader>;
-  let props: LoaderSizeMarginProps;
   const defaultColor = "#000000";
   const defaultSize = 15;
   const defaultMargin = 2;
   const defaultUnit = "px";
 
-  it("should match snapshot", () => {
-    loader = mount(<BeatLoader />);
-    expect(loader).toMatchSnapshot();
-  });
-
-  it("should contain default props if no props are passed", () => {
-    props = loader.props();
-    expect(props).toEqual(sizeMarginDefaults(defaultSize));
-  });
+  commonSpecs(BeatLoader, sizeMarginDefaults(defaultSize));
 
   it("should contain styles created using default props", () => {
-    props = loader.props();
+    const loader = mount(<BeatLoader />);
     expect(loader.find("span span")).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
     expect(loader.find("span span")).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
     expect(loader.find("span span")).toHaveStyleRule("margin", `${defaultMargin}${defaultUnit}`);
     expect(loader.find("span span")).toHaveStyleRule("background-color", defaultColor);
   });
 
-  it("should render null if loading prop is set as false", () => {
-    loader = mount(<BeatLoader loading={false} />);
-    expect(loader.isEmptyRender()).toBe(true);
-  });
-
   it("should render the correct color based on prop", () => {
-    loader = mount(<BeatLoader color="#e2e2e2" />);
+    const loader = mount(<BeatLoader color="#e2e2e2" />);
     expect(loader.find("span span")).not.toHaveStyleRule("background-color", defaultColor);
     expect(loader.find("span span")).toHaveStyleRule("background-color", "#e2e2e2");
   });
@@ -47,8 +32,11 @@ describe("BeatLoader", () => {
   describe("size prop", () => {
     it("should render the size with px unit when size is a number", () => {
       const size = 18;
-      loader = mount(<BeatLoader size={18} />);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      const loader = mount(<BeatLoader size={18} />);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
       expect(loader.find("span span")).toHaveStyleRule("height", `${size}${defaultUnit}`);
       expect(loader.find("span span")).toHaveStyleRule("width", `${size}${defaultUnit}`);
@@ -56,8 +44,11 @@ describe("BeatLoader", () => {
 
     it("should render the size as is when size is a string with valid css unit", () => {
       const size = "18px";
-      loader = mount(<BeatLoader size={size} />);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      const loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
       expect(loader.find("span span")).toHaveStyleRule("height", `${size}`);
       expect(loader.find("span span")).toHaveStyleRule("width", `${size}`);
@@ -67,8 +58,11 @@ describe("BeatLoader", () => {
       const length = 18;
       const unit = "ad";
       const size = `${length}${unit}`;
-      loader = mount(<BeatLoader size={size} />);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      const loader = mount(<BeatLoader size={size} />);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
       expect(loader.find("span span")).toHaveStyleRule("height", `${length}${defaultUnit}`);
       expect(loader.find("span span")).toHaveStyleRule("width", `${length}${defaultUnit}`);
@@ -78,7 +72,7 @@ describe("BeatLoader", () => {
   describe("margin prop", () => {
     it("should render the margin with px unit when margin is a number", () => {
       const margin = 18;
-      loader = mount(<BeatLoader margin={18} />);
+      const loader = mount(<BeatLoader margin={18} />);
       expect(loader.find("span span")).not.toHaveStyleRule(
         "margin",
         `${defaultMargin}${defaultUnit}`
@@ -88,7 +82,7 @@ describe("BeatLoader", () => {
 
     it("should render the margin as is when margin is a string with valid css unit", () => {
       const margin = "18px";
-      loader = mount(<BeatLoader margin={margin} />);
+      const loader = mount(<BeatLoader margin={margin} />);
       expect(loader.find("span span")).not.toHaveStyleRule(
         "margin",
         `${defaultMargin}${defaultUnit}`
@@ -100,7 +94,7 @@ describe("BeatLoader", () => {
       const length = 18;
       const unit = "ad";
       const margin = `${length}${unit}`;
-      loader = mount(<BeatLoader margin={margin} />);
+      const loader = mount(<BeatLoader margin={margin} />);
       expect(loader.find("span span")).not.toHaveStyleRule(
         "margin",
         `${defaultMargin}${defaultUnit}`
@@ -110,7 +104,7 @@ describe("BeatLoader", () => {
   });
 
   it("should render the css override based on props", () => {
-    loader = mount(<BeatLoader css={"position: absolute; overflow: scroll;"} />);
+    const loader = mount(<BeatLoader css={"position: absolute; overflow: scroll;"} />);
     expect(loader).toHaveStyleRule("position", "absolute");
     expect(loader).toHaveStyleRule("overflow", "scroll");
   });

--- a/__tests__/BounceLoader-tests.tsx
+++ b/__tests__/BounceLoader-tests.tsx
@@ -1,30 +1,21 @@
 import * as React from "react";
-import { mount, ReactWrapper } from "enzyme";
-import { matchers } from '@emotion/jest';
+import { mount } from "enzyme";
+import { matchers } from "@emotion/jest";
 expect.extend(matchers);
 
 import BounceLoader from "../src/BounceLoader";
-import { LoaderSizeProps } from "../src/interfaces";
 import { sizeDefaults } from "../src/helpers";
+import { commonSpecs } from "./sharedSpecs/commonSpecs";
 
 describe("BounceLoader", () => {
-  let loader: ReactWrapper<LoaderSizeProps, null, BounceLoader>;
-  let props: LoaderSizeProps;
   const defaultColor = "#000000";
   const defaultSize = 60;
   const defaultUnit = "px";
 
-  it("should match snapshot", () => {
-    loader = mount(<BounceLoader />);
-    expect(loader).toMatchSnapshot();
-  });
-
-  it("should contain default props if no props are passed", () => {
-    props = loader.props();
-    expect(props).toEqual(sizeDefaults(defaultSize));
-  });
+  commonSpecs(BounceLoader, sizeDefaults(defaultSize));
 
   it("should contain styles created using default props", () => {
+    const loader = mount(<BounceLoader />);
     expect(loader).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
     expect(loader).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
     expect(loader.find("span span")).toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
@@ -32,14 +23,9 @@ describe("BounceLoader", () => {
     expect(loader.find("span span")).toHaveStyleRule("background-color", defaultColor);
   });
 
-  it("should render null if loading prop is set as false", () => {
-    loader = mount(<BounceLoader loading={false} />);
-    expect(loader.isEmptyRender()).toBe(true);
-  });
-
   it("should render the correct color based on prop", () => {
     const color = "#e2e2e2";
-    loader = mount(<BounceLoader color={color} />);
+    const loader = mount(<BounceLoader color={color} />);
     expect(loader.find("span span")).not.toHaveStyleRule("background-color", defaultColor);
     expect(loader.find("span span")).toHaveStyleRule("background-color", color);
   });
@@ -47,10 +33,13 @@ describe("BounceLoader", () => {
   describe("size prop", () => {
     it("should render the size with px unit when size is a number", () => {
       const size = 18;
-      loader = mount(<BounceLoader size={size} />);
+      const loader = mount(<BounceLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${size}${defaultUnit}`);
@@ -61,10 +50,13 @@ describe("BounceLoader", () => {
 
     it("should render the size as is when size is a string with valid css unit", () => {
       const size = "18px";
-      loader = mount(<BounceLoader size={size} />);
+      const loader = mount(<BounceLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${size}`);
@@ -77,10 +69,13 @@ describe("BounceLoader", () => {
       const length = 18;
       const unit = "ad";
       const size = `${length}${unit}`;
-      loader = mount(<BounceLoader size={size} />);
+      const loader = mount(<BounceLoader size={size} />);
       expect(loader).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
       expect(loader).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
-      expect(loader.find("span span")).not.toHaveStyleRule("height", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span")).not.toHaveStyleRule(
+        "height",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span")).not.toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
 
       expect(loader).toHaveStyleRule("height", `${length}${defaultUnit}`);
@@ -91,7 +86,7 @@ describe("BounceLoader", () => {
   });
 
   it("should render the css override based on props", () => {
-    loader = mount(<BounceLoader css={"position: absolute; overflow: scroll;"} />);
+    const loader = mount(<BounceLoader css={"position: absolute; overflow: scroll;"} />);
     expect(loader).not.toHaveStyleRule("position", "relative");
     expect(loader).toHaveStyleRule("position", "absolute");
     expect(loader).toHaveStyleRule("overflow", "scroll");

--- a/__tests__/PulseLoader-test.tsx
+++ b/__tests__/PulseLoader-test.tsx
@@ -1,38 +1,32 @@
 import * as React from "react";
-import { mount, ReactWrapper } from "enzyme";
-import { matchers } from '@emotion/jest';
+import { mount } from "enzyme";
+import { matchers } from "@emotion/jest";
 expect.extend(matchers);
 
 import PulseLoader from "../src/PulseLoader";
-import { LoaderSizeMarginProps } from "../src/interfaces";
 import { sizeMarginDefaults } from "../src/helpers";
+import { commonSpecs } from "./sharedSpecs/commonSpecs";
 
 describe("PulseLoader", () => {
-  let loader: ReactWrapper;
-  let props: LoaderSizeMarginProps;
   const defaultSize = 15;
   const defaultMargin = 2;
   const defaultColor = "#000000";
   const defaultUnit = "px";
 
-  it("should match snapshot", () => {
-    loader = mount(<PulseLoader />);
-    expect(loader).toMatchSnapshot();
-  });
-
-  it("should contain default props if no props are passed", () => {
-    props = loader.props();
-    expect(props).toEqual(sizeMarginDefaults(defaultSize));
-  });
+  commonSpecs(PulseLoader, sizeMarginDefaults(defaultSize));
 
   it("should contain styles created using default props", () => {
+    const loader = mount(<PulseLoader />);
     for (let i = 0; i < 3; i++) {
       expect(loader.find("span span").at(i)).toHaveStyleRule("background-color", defaultColor);
       expect(loader.find("span span").at(i)).toHaveStyleRule(
         "height",
         `${defaultSize}${defaultUnit}`
       );
-      expect(loader.find("span span").at(i)).toHaveStyleRule("width", `${defaultSize}${defaultUnit}`);
+      expect(loader.find("span span").at(i)).toHaveStyleRule(
+        "width",
+        `${defaultSize}${defaultUnit}`
+      );
       expect(loader.find("span span").at(i)).toHaveStyleRule(
         "margin",
         `${defaultMargin}${defaultUnit}`
@@ -40,14 +34,9 @@ describe("PulseLoader", () => {
     }
   });
 
-  it("should render null if loading prop is set as false", () => {
-    loader = mount(<PulseLoader loading={false} />);
-    expect(loader.isEmptyRender()).toBe(true);
-  });
-
   it("should render the correct color based on prop", () => {
     const color = "#e2e2e2";
-    loader = mount(<PulseLoader color={color} />);
+    const loader = mount(<PulseLoader color={color} />);
     for (let i = 0; i < 3; i++) {
       expect(loader.find("span span").at(i)).not.toHaveStyleRule("background-color", defaultColor);
       expect(loader.find("span span").at(i)).toHaveStyleRule("background-color", color);
@@ -57,7 +46,7 @@ describe("PulseLoader", () => {
   describe("size props", () => {
     it("should render the size with px unit when size is a number", () => {
       const size = 18;
-      loader = mount(<PulseLoader size={size} />);
+      const loader = mount(<PulseLoader size={size} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -76,7 +65,7 @@ describe("PulseLoader", () => {
 
     it("should render the size as is when size is a string with valid css unit", () => {
       const size = "18px";
-      loader = mount(<PulseLoader size={size} />);
+      const loader = mount(<PulseLoader size={size} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -97,7 +86,7 @@ describe("PulseLoader", () => {
       const length = 18;
       const unit = "ad";
       const size = `${length}${unit}`;
-      loader = mount(<PulseLoader size={size} />);
+      const loader = mount(<PulseLoader size={size} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -118,7 +107,7 @@ describe("PulseLoader", () => {
   describe("margin props", () => {
     it("should render the margin with px unit when margin is a number", () => {
       const margin = 18;
-      loader = mount(<PulseLoader margin={margin} />);
+      const loader = mount(<PulseLoader margin={margin} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -131,7 +120,7 @@ describe("PulseLoader", () => {
 
     it("should render the margin as is when margin is a string with valid css unit", () => {
       const margin = "18px";
-      loader = mount(<PulseLoader margin={margin} />);
+      const loader = mount(<PulseLoader margin={margin} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -146,7 +135,7 @@ describe("PulseLoader", () => {
       const length = 18;
       const unit = "ad";
       const margin = `${length}${unit}`;
-      loader = mount(<PulseLoader margin={margin} />);
+      const loader = mount(<PulseLoader margin={margin} />);
 
       for (let i = 0; i < 3; i++) {
         expect(loader.find("span span").at(i)).not.toHaveStyleRule(
@@ -156,12 +145,5 @@ describe("PulseLoader", () => {
         expect(loader.find("span span").at(i)).toHaveStyleRule("margin", `${length}${defaultUnit}`);
       }
     });
-  });
-
-  it("should render the css override based on props", () => {
-    loader = mount(<PulseLoader css={"position: fixed; width: 100px; color: blue;"} />);
-    expect(loader).toHaveStyleRule("position", "fixed");
-    expect(loader).toHaveStyleRule("width", "100px");
-    expect(loader).toHaveStyleRule("color", "blue");
   });
 });

--- a/__tests__/PulseLoader-test.tsx
+++ b/__tests__/PulseLoader-test.tsx
@@ -146,4 +146,11 @@ describe("PulseLoader", () => {
       }
     });
   });
+
+  it("should render the css override based on props", () => {
+    const loader = mount(<PulseLoader css={"position: fixed; width: 100px; color: blue;"} />);
+    expect(loader).toHaveStyleRule("position", "fixed");
+    expect(loader).toHaveStyleRule("width", "100px");
+    expect(loader).toHaveStyleRule("color", "blue");
+  });
 });

--- a/__tests__/sharedSpecs/commonSpecs.tsx
+++ b/__tests__/sharedSpecs/commonSpecs.tsx
@@ -23,12 +23,4 @@ export function commonSpecs(Loader: typeof React.Component, defaultProps: unknow
     const loader = mount(<Loader loading={false} />);
     expect(loader.isEmptyRender()).toBe(true);
   });
-
-  it("should render the css override based on props", () => {
-    const loader = mount(<Loader css={"position: absolute; overflow: scroll;"} />);
-    expect(loader).not.toHaveStyleRule("position", "relative");
-    expect(loader).toHaveStyleRule("position", "absolute");
-    expect(loader).not.toHaveStyleRule("overflow", "hidden");
-    expect(loader).toHaveStyleRule("overflow", "scroll");
-  });
 }

--- a/__tests__/sharedSpecs/commonSpecs.tsx
+++ b/__tests__/sharedSpecs/commonSpecs.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { mount } from "enzyme";
+import { matchers } from "@emotion/jest";
+import BarLoader from "../../src/BarLoader";
+import PulseLoader from "../../src/PulseLoader";
+import { LoaderHeightWidthProps, LoaderSizeMarginProps } from "../../src/interfaces";
+expect.extend(matchers);
+
+export function commonSpecs(Loader: typeof BarLoader, defaultProps: LoaderHeightWidthProps): void;
+export function commonSpecs(Loader: typeof PulseLoader, defaultProps: LoaderSizeMarginProps): void;
+export function commonSpecs(Loader: typeof React.Component, defaultProps: unknown): void {
+  it("should match snapshot", () => {
+    const loader = mount(<Loader />);
+    expect(loader).toMatchSnapshot();
+  });
+
+  it("should contain default props if no props are passed", () => {
+    const loader = mount(<Loader />);
+    expect(loader.props()).toEqual(defaultProps);
+  });
+
+  it("should render null if loading prop is set as false", () => {
+    const loader = mount(<Loader loading={false} />);
+    expect(loader.isEmptyRender()).toBe(true);
+  });
+
+  it("should render the css override based on props", () => {
+    const loader = mount(<Loader css={"position: absolute; overflow: scroll;"} />);
+    expect(loader).not.toHaveStyleRule("position", "relative");
+    expect(loader).toHaveStyleRule("position", "absolute");
+    expect(loader).not.toHaveStyleRule("overflow", "hidden");
+    expect(loader).toHaveStyleRule("overflow", "scroll");
+  });
+}

--- a/__tests__/sharedSpecs/commonSpecs.tsx
+++ b/__tests__/sharedSpecs/commonSpecs.tsx
@@ -1,13 +1,8 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import { matchers } from "@emotion/jest";
-import BarLoader from "../../src/BarLoader";
-import PulseLoader from "../../src/PulseLoader";
-import { LoaderHeightWidthProps, LoaderSizeMarginProps } from "../../src/interfaces";
 expect.extend(matchers);
 
-export function commonSpecs(Loader: typeof BarLoader, defaultProps: LoaderHeightWidthProps): void;
-export function commonSpecs(Loader: typeof PulseLoader, defaultProps: LoaderSizeMarginProps): void;
 export function commonSpecs(Loader: typeof React.Component, defaultProps: unknown): void {
   it("should match snapshot", () => {
     const loader = mount(<Loader />);

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,11 @@ module.exports = {
   coverageDirectory: "./coverage",
   moduleDirectories: ["node_modules"],
   setupFiles: ["<rootDir>/__tests__/config/enzyme.ts"],
-  testPathIgnorePatterns: ["<rootDir>/__tests__/config/*", "<rootDir>/__tests__/mock/*"],
+  testPathIgnorePatterns: [
+    "<rootDir>/__tests__/config/*",
+    "<rootDir>/__tests__/mock/*",
+    "<rootDir>/__tests__/sharedSpecs/*"
+  ],
   transform: {
     ".(ts|tsx|js|jsx)": "ts-jest"
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,7 +3,7 @@ module.exports = {
   tabWidth: 2,
   useTabs: false,
   semi: true,
-  printWidth: 100,
+  printWidth: 120,
   bracketSpacing: true,
   jsxBracketSameLine: false,
   arrowParens: "always"


### PR DESCRIPTION
```
  it("should match snapshot", () => {
  it("should contain default props if no props are passed", () => {
  it("should render null if loading prop is set as false", () => {
```

these 4 tests are now moved to a commonSpec file and runs for all loaders