### PR TITLE
update jsx pragma to emotion/react

### DIFF
--- a/src/BarLoader.tsx
+++ b/src/BarLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 
@@ -33,12 +33,8 @@ class Loader extends React.PureComponent<Required<LoaderHeightWidthProps>> {
       border-radius: 2px;
       will-change: left, right;
       animation-fill-mode: forwards;
-      animation: ${i === 1 ? long : short} ${2.1 / speedMultiplier}s
-        ${i === 2 ? `${1.15 / speedMultiplier}s` : ""}
-        ${i === 1
-          ? "cubic-bezier(0.65, 0.815, 0.735, 0.395)"
-          : "cubic-bezier(0.165, 0.84, 0.44, 1)"}
-        infinite;
+      animation: ${i === 1 ? long : short} ${2.1 / speedMultiplier}s ${i === 2 ? `${1.15 / speedMultiplier}s` : ""}
+        ${i === 1 ? "cubic-bezier(0.65, 0.815, 0.735, 0.395)" : "cubic-bezier(0.165, 0.84, 0.44, 1)"} infinite;
     `;
   };
 

--- a/src/BeatLoader.tsx
+++ b/src/BeatLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 
@@ -23,8 +23,7 @@ class Loader extends React.PureComponent<Required<LoaderSizeMarginProps>> {
       height: ${cssValue(size)};
       margin: ${cssValue(margin)};
       border-radius: 100%;
-      animation: ${beat} ${0.7 / speedMultiplier}s ${i % 2 ? "0s" : `${0.35 / speedMultiplier}s`}
-        infinite linear;
+      animation: ${beat} ${0.7 / speedMultiplier}s ${i % 2 ? "0s" : `${0.35 / speedMultiplier}s`} infinite linear;
       animation-fill-mode: both;
     `;
   };

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 
@@ -26,8 +26,7 @@ class Loader extends React.PureComponent<Required<LoaderSizeProps>> {
       top: 0;
       left: 0;
       animation-fill-mode: both;
-      animation: ${bounce} ${2.1 / speedMultiplier}s ${i === 1 ? `${1 / speedMultiplier}s` : "0s"}
-        infinite ease-in-out;
+      animation: ${bounce} ${2.1 / speedMultiplier}s ${i === 1 ? `${1 / speedMultiplier}s` : "0s"} infinite ease-in-out;
     `;
   };
 

--- a/src/CircleLoader.tsx
+++ b/src/CircleLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/ClimbingBoxLoader.tsx
+++ b/src/ClimbingBoxLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/ClipLoader.tsx
+++ b/src/ClipLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/ClockLoader.tsx
+++ b/src/ClockLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/DotLoader.tsx
+++ b/src/DotLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/FadeLoader.tsx
+++ b/src/FadeLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/HashLoader.tsx
+++ b/src/HashLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 import { Keyframes } from "@emotion/serialize";

--- a/src/MoonLoader.tsx
+++ b/src/MoonLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/PacmanLoader.tsx
+++ b/src/PacmanLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 import { Keyframes } from "@emotion/serialize";

--- a/src/PropagateLoader.tsx
+++ b/src/PropagateLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/PuffLoader.tsx
+++ b/src/PuffLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/PulseLoader.tsx
+++ b/src/PulseLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/RingLoader.tsx
+++ b/src/RingLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/RiseLoader.tsx
+++ b/src/RiseLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/RotateLoader.tsx
+++ b/src/RotateLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/ScaleLoader.tsx
+++ b/src/ScaleLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/SkewLoader.tsx
+++ b/src/SkewLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/SquareLoader.tsx
+++ b/src/SquareLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 

--- a/src/SyncLoader.tsx
+++ b/src/SyncLoader.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxImportSource @emotion/react */
 import * as React from "react";
 import { keyframes, css, jsx, SerializedStyles } from "@emotion/react";
 


### PR DESCRIPTION
> If you are using a zero-config tool with automatic detection of which runtime (classic vs. automatic) should be used and you are already using a React version that has the new JSX runtimes (hence runtime: 'automatic' being configured automatically for you) such as Create React App 4 then /** @jsx jsx */ pragma might not work and you should use /** @jsxImportSource @emotion/react */ instead.

from the emotion documenation. 

https://emotion.sh/docs/css-prop#jsx-pragma