### PR TITLE
demo site action do not fail on alpha / beta verions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: get current package version
         id: current-version
-        run: echo ::set-output name=value::$(cat ${PACKAGE_JSON_PATH}/package.json | jq '.version' | tr -d '"')
+        run: echo ::set-output name=value::$(cat package.json | jq '.version' | tr -d '"')
       - name: check if current version is alpha or beta
         id: pre-release
         run: echo ::set-output name=value::${{ contains(steps.current-version.outputs.value, 'alpha') || contains(steps.current-version.outputs.value, 'beta') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: get current package version
+        id: current-version
+        run: echo ::set-output name=value::$(cat ${PACKAGE_JSON_PATH}/package.json | jq '.version' | tr -d '"')
+      - name: check if current version is alpha or beta
+        id: pre-release
+        run: echo ::set-output name=value::${{ contains(steps.current-version.outputs.value, 'alpha') || contains(steps.current-version.outputs.value, 'beta') }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -83,5 +89,5 @@ jobs:
         id: changes
         run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
       - name: error out if there are any changes
-        if: steps.changes.outputs.changed != 0
+        if: steps.changes.outputs.changed != 0 || steps.pre-release.outputs.value != 'true'
         run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,6 @@ jobs:
       - name: check if there is any change
         id: changes
         run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
-      - name: error out if there are any changes
+      - name: error out if there are any changes and package isn't pre-release
         if: steps.changes.outputs.changed != 0 && steps.pre-release.outputs.value != 'true'
         run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,5 +89,5 @@ jobs:
         id: changes
         run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
       - name: error out if there are any changes
-        if: steps.changes.outputs.changed != 0 || steps.pre-release.outputs.value != 'true'
+        if: steps.changes.outputs.changed != 0 && steps.pre-release.outputs.value != 'true'
         run: exit 1


### PR DESCRIPTION
While the package is in beta or alpha, the demo site action shouldn't fail since we don't want to update the site code 