### PR TITLE
Add important to width and height to prevent overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.13.0-alpha.5
+
+- **bugfix**: Update `GridLoader` height/width with `important` tag to prevent overwrites from outside css.
+
 ## 0.13.0-alpha.4
 
 - **Feature**: Add support for custom props in all loaders.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinners",
-  "version": "0.13.0-alpha.4",
+  "version": "0.13.0-alpha.5",
   "description": "A collection of react loading spinners",
   "repository": {
     "type": "git",

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -36,8 +36,8 @@ function GridLoader({
     return {
       display: "inline-block",
       backgroundColor: color,
-      width: cssValue(size),
-      height: cssValue(size),
+      width: `${cssValue(size)} !important`,
+      height: `${cssValue(size)} !important`,
       margin: cssValue(margin),
       borderRadius: "100%",
       animationFillMode: "both",


### PR DESCRIPTION
an attempt to resolve #386. thinking is the width is overwritten somehow causing the grid to not render properly

as a test, we can try to overwrite the width this way.
```
<GridLoader css={{ width: 300 }} />
```
This fix won't prevent the above from happening, but should prevent overrides from outside css. 