### PR TITLE
Fix GridLoader not showing issue, bump to bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.13.0-beta.1
+
+- **bugfix**: Properly assign important tag to `GridLoader` width prop.
+
 ## 0.13.0-alpha.5
 
 - **bugfix**: Update `GridLoader` height/width with `important` tag to prevent overwrites from outside css.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinners",
-  "version": "0.13.0-alpha.5",
+  "version": "0.13.0-beta.1",
   "description": "A collection of react loading spinners",
   "repository": {
     "type": "git",

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -36,8 +36,8 @@ function GridLoader({
     return {
       display: "inline-block",
       backgroundColor: color,
-      width: `${cssValue(size)} !important`,
-      height: `${cssValue(size)} !important`,
+      width: `${cssValue(size)}`,
+      height: `${cssValue(size)}`,
       margin: cssValue(margin),
       borderRadius: "100%",
       animationFillMode: "both",
@@ -50,7 +50,15 @@ function GridLoader({
   }
 
   return (
-    <span style={wrapper} {...additionalprops}>
+    <span
+      style={wrapper}
+      {...additionalprops}
+      ref={(node) => {
+        if (node) {
+          node.style.setProperty("width", `${width}${sizeWithUnit.unit}`, "important");
+        }
+      }}
+    >
       <span style={style(random(100))} />
       <span style={style(random(100))} />
       <span style={style(random(100))} />


### PR DESCRIPTION
# What changes are introduced?
the important tag is assigned to the wrong height width. it should be on the outside `span`. Also, inline important tag doesn't work, so used ref instead 

# Any screenshots?
<img width="544" alt="Screen Shot 2022-05-25 at 10 31 27 PM" src="https://user-images.githubusercontent.com/15827041/170422838-c4a44fac-5ca6-45a9-9270-d1589527dcac.png">

<img width="334" alt="Screen Shot 2022-05-25 at 10 31 30 PM" src="https://user-images.githubusercontent.com/15827041/170422845-12bf8b61-a1e8-4be1-a960-c7c04a7f48ef.png">


