### PR TITLE
Remove Animation Fill Mode

### DIFF
--- a/src/CircleLoader.tsx
+++ b/src/CircleLoader.tsx
@@ -41,7 +41,6 @@ function CircleLoader({
       transition: "2s",
       top: `${i * 0.7 * 2.5}%`,
       left: `${i * 0.35 * 2.5}%`,
-      animationFillMode: "",
       animation: `${circle} ${1 / speedMultiplier}s ${(i * 0.2) / speedMultiplier}s infinite linear`,
     };
   };


### PR DESCRIPTION
# What changes are introduced?
Animation fill mode property removed. I am using next, and it is throwing errors, as the server side does not load empty CSS properties.
# Any screenshots?
![image](https://user-images.githubusercontent.com/20777515/208742407-f9e2f759-f118-44de-ae20-dd158e3547e1.png)
