### PR TITLE
chore: remove-jsx-element return type

### DIFF
--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -42,9 +42,13 @@ function SpinnerExamples() {
           <button onClick={togglePicker}>Change Color</button>
         )}
       </div>
-
       {Object.entries(Spinners).map(([name, loader]) => (
-        <LoaderItem key={`loader-${name}`} color={color} name={name} Spinner={loader} />
+        <LoaderItem
+          key={`loader-${name}`}
+          color={color}
+          name={name}
+          Spinner={loader as React.ComponentType<any>}
+        />
       ))}
     </div>
   );

--- a/scripts/mod.rb
+++ b/scripts/mod.rb
@@ -41,7 +41,7 @@ content.sub!(/class Loader extends React.PureComponent<Required<(.+)>> {/) do
    "  css = {},",
    "  #{props}",
    "  ...additionalprops",
-   "}: #{$1}): React.JSX.Element | null  {"].join("\n")
+   "}: #{$1})  {"].join("\n")
 end
 
 content.sub!(/public static defaultProps = .+;/, "")
@@ -67,7 +67,7 @@ end
 content.gsub!("css=", "style=")
 content.gsub!("{this.", "{")
 
-content.gsub!("public render(): React.JSX.Element | null  {", "")
+content.gsub!("public render()  {", "")
 content.gsub!(/}\n\s+}/, "}")
 
 content.gsub!("return loading ? (", "if (!loading) { return null; }\n\n return (")

--- a/src/BarLoader.tsx
+++ b/src/BarLoader.tsx
@@ -25,7 +25,7 @@ function BarLoader({
   height = 4,
   width = 100,
   ...additionalprops
-}: LoaderHeightWidthProps): React.JSX.Element | null {
+}: LoaderHeightWidthProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     position: "relative",

--- a/src/BeatLoader.tsx
+++ b/src/BeatLoader.tsx
@@ -19,7 +19,7 @@ function BeatLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,

--- a/src/BounceLoader.tsx
+++ b/src/BounceLoader.tsx
@@ -17,7 +17,7 @@ function BounceLoader({
   cssOverride = {},
   size = 60,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const style = (i: number): React.CSSProperties => {
     const animationTiming = i === 1 ? `${1 / speedMultiplier}s` : "0s";
     return {

--- a/src/CircleLoader.tsx
+++ b/src/CircleLoader.tsx
@@ -17,7 +17,7 @@ function CircleLoader({
   cssOverride = {},
   size = 50,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     position: "relative",

--- a/src/ClimbingBoxLoader.tsx
+++ b/src/ClimbingBoxLoader.tsx
@@ -27,7 +27,7 @@ function ClimbingBoxLoader({
   cssOverride = {},
   size = 15,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const container: React.CSSProperties = {
     display: "inherit",
     position: "relative",

--- a/src/ClipLoader.tsx
+++ b/src/ClipLoader.tsx
@@ -17,7 +17,7 @@ function ClipLoader({
   cssOverride = {},
   size = 35,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const style: React.CSSProperties = {
     background: "transparent !important",
     width: cssValue(size),

--- a/src/ClockLoader.tsx
+++ b/src/ClockLoader.tsx
@@ -13,7 +13,7 @@ function ClockLoader({
   cssOverride = {},
   size = 50,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const { value, unit } = parseLengthAndUnit(size);
 
   const wrapper: React.CSSProperties = {

--- a/src/DotLoader.tsx
+++ b/src/DotLoader.tsx
@@ -19,7 +19,7 @@ function DotLoader({
   cssOverride = {},
   size = 60,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     position: "relative",

--- a/src/FadeLoader.tsx
+++ b/src/FadeLoader.tsx
@@ -16,7 +16,7 @@ function FadeLoader({
   radius = 2,
   margin = 2,
   ...additionalprops
-}: LoaderHeightWidthRadiusProps): React.JSX.Element | null {
+}: LoaderHeightWidthRadiusProps) {
   const { value } = parseLengthAndUnit(margin);
   const radiusValue = value + 18;
   const quarter = radiusValue / 2 + radiusValue / 5.5;

--- a/src/GridLoader.tsx
+++ b/src/GridLoader.tsx
@@ -20,7 +20,7 @@ function GridLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const sizeWithUnit = parseLengthAndUnit(size);
   const marginWithUnit = parseLengthAndUnit(margin);
 

--- a/src/HashLoader.tsx
+++ b/src/HashLoader.tsx
@@ -12,7 +12,7 @@ function HashLoader({
   cssOverride = {},
   size = 50,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const { value, unit } = parseLengthAndUnit(size);
 
   const wrapper: React.CSSProperties = {

--- a/src/MoonLoader.tsx
+++ b/src/MoonLoader.tsx
@@ -13,7 +13,7 @@ function MoonLoader({
   cssOverride = {},
   size = 60,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const { value, unit } = parseLengthAndUnit(size);
   const moonSize = Math.round(value / 7);
 

--- a/src/PacmanLoader.tsx
+++ b/src/PacmanLoader.tsx
@@ -25,7 +25,7 @@ function PacmanLoader({
   size = 25,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const { value, unit } = parseLengthAndUnit(size);
 
   const wrapper: React.CSSProperties = {

--- a/src/PropagateLoader.tsx
+++ b/src/PropagateLoader.tsx
@@ -63,7 +63,7 @@ function PropagateLoader({
   cssOverride = {},
   size = 15,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const { value, unit } = parseLengthAndUnit(size);
 
   const wrapper: React.CSSProperties = {

--- a/src/PuffLoader.tsx
+++ b/src/PuffLoader.tsx
@@ -16,7 +16,7 @@ function PuffLoader({
   cssOverride = {},
   size = 60,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     position: "relative",

--- a/src/PulseLoader.tsx
+++ b/src/PulseLoader.tsx
@@ -18,7 +18,7 @@ function PulseLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,

--- a/src/RingLoader.tsx
+++ b/src/RingLoader.tsx
@@ -23,7 +23,7 @@ function RingLoader({
   cssOverride = {},
   size = 60,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const { value, unit } = parseLengthAndUnit(size);
 
   const wrapper: React.CSSProperties = {

--- a/src/RiseLoader.tsx
+++ b/src/RiseLoader.tsx
@@ -12,7 +12,7 @@ function RiseLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,

--- a/src/RotateLoader.tsx
+++ b/src/RotateLoader.tsx
@@ -18,7 +18,7 @@ function RotateLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const { value, unit } = parseLengthAndUnit(margin);
 
   const ball: React.CSSProperties = {

--- a/src/ScaleLoader.tsx
+++ b/src/ScaleLoader.tsx
@@ -21,7 +21,7 @@ function ScaleLoader({
   margin = 2,
   barCount = 5,
   ...additionalprops
-}: LoaderHeightWidthRadiusProps & { barCount: number }): React.JSX.Element | null {
+}: LoaderHeightWidthRadiusProps & { barCount: number }) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,

--- a/src/SkewLoader.tsx
+++ b/src/SkewLoader.tsx
@@ -17,7 +17,7 @@ function SkewLoader({
   cssOverride = {},
   size = 20,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const style: React.CSSProperties = {
     width: "0",
     height: "0",

--- a/src/SquareLoader.tsx
+++ b/src/SquareLoader.tsx
@@ -20,7 +20,7 @@ function SquareLoader({
   cssOverride = {},
   size = 50,
   ...additionalprops
-}: LoaderSizeProps): React.JSX.Element | null {
+}: LoaderSizeProps) {
   const style: React.CSSProperties = {
     backgroundColor: color,
     width: cssValue(size),

--- a/src/SyncLoader.tsx
+++ b/src/SyncLoader.tsx
@@ -20,7 +20,7 @@ function SyncLoader({
   size = 15,
   margin = 2,
   ...additionalprops
-}: LoaderSizeMarginProps): React.JSX.Element | null {
+}: LoaderSizeMarginProps) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,


### PR DESCRIPTION
# What changes are introduced?
return type isn't necessary, so we can remove it to keep things simple

# Any screenshots?
