### PR TITLE
chore: fix-color-picker throw exception 

### DIFF
--- a/examples/components/ColorPicker.tsx
+++ b/examples/components/ColorPicker.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import enhanceWithClickOutside from "react-click-outside";
 import { HexAlphaColorPicker } from "react-colorful";
 
 interface ColorPickerProps {
@@ -8,16 +7,23 @@ interface ColorPickerProps {
   updateColor: (color: string) => void;
 }
 
-class Picker extends React.Component<ColorPickerProps> {
-  public handleClickOutside(): void {
-    this.props.togglePicker();
-  }
-
-  public render(): JSX.Element {
-    const { color, updateColor } = this.props;
-
-    return <HexAlphaColorPicker color={color} onChange={updateColor} />;
-  }
+function Picker({ togglePicker, color, updateColor }: ColorPickerProps) {
+  return (
+    <div>
+      <HexAlphaColorPicker color={color} onChange={updateColor} />
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          height: "100vh",
+          width: "100vw",
+          zIndex: -1,
+        }}
+        onClick={togglePicker}
+      ></div>
+    </div>
+  );
 }
 
-export default enhanceWithClickOutside(Picker);
+export default Picker;

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -29,17 +29,20 @@ function SpinnerExamples() {
     `;
   }
 
-  function togglePicker() {
-    setShowPicker(!showPicker);
+  function handleShowPicker() {
+    setShowPicker(true);
+  }
+  function handleHidePicker() {
+    setShowPicker(false);
   }
 
   return (
     <div className="spinner-container">
       <div className="color-picker position-abs">
         {showPicker ? (
-          <ColorPicker color={color} updateColor={updateColor} togglePicker={togglePicker} />
+          <ColorPicker color={color} updateColor={updateColor} togglePicker={handleHidePicker} />
         ) : (
-          <button onClick={togglePicker}>Change Color</button>
+          <button onClick={handleShowPicker}>Change Color</button>
         )}
       </div>
       {Object.entries(Spinners).map(([name, loader]) => (

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -82,14 +82,22 @@ code {
   padding: 16px 32px;
   font-size: 20px;
   margin: 0 auto;
-  font-family: Courier New, Courier, monospace;
+  font-family:
+    Courier New,
+    Courier,
+    monospace;
   opacity: 0.9;
 }
 
 code:hover {
-  -webkit-box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12),
+  -webkit-box-shadow:
+    0 3px 3px 0 rgba(0, 0, 0, 0.14),
+    0 1px 7px 0 rgba(0, 0, 0, 0.12),
     0 3px 1px -1px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -1px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 3px 3px 0 rgba(0, 0, 0, 0.14),
+    0 1px 7px 0 rgba(0, 0, 0, 0.12),
+    0 3px 1px -1px rgba(0, 0, 0, 0.2);
   opacity: 1;
 }
 
@@ -180,9 +188,14 @@ code:hover {
 }
 
 .color-picker button:hover {
-  -webkit-box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12),
+  -webkit-box-shadow:
+    0 3px 3px 0 rgba(0, 0, 0, 0.14),
+    0 1px 7px 0 rgba(0, 0, 0, 0.12),
     0 3px 1px -1px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -1px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 3px 3px 0 rgba(0, 0, 0, 0.14),
+    0 1px 7px 0 rgba(0, 0, 0, 0.12),
+    0 3px 1px -1px rgba(0, 0, 0, 0.2);
   opacity: 1;
 }
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.5.3",
     "react": "^19.1.0",
-    "react-click-outside": "^3.0.1",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0",
     "react-ga4": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5099,13 +5099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^2.1.1":
-  version: 2.5.5
-  resolution: "hoist-non-react-statics@npm:2.5.5"
-  checksum: 10/5cd8f04dc3adec5e19fa4dd05a03216b0237e98d870064f4232e6339e9bbe1bd07b41cca2bb6e999c328b409271c1eefde299a69ca75aff510acdd4e7b3d340e
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^7.0.0":
   version: 7.0.2
   resolution: "hosted-git-info@npm:7.0.2"
@@ -7535,15 +7528,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-click-outside@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "react-click-outside@npm:3.0.1"
-  dependencies:
-    hoist-non-react-statics: "npm:^2.1.1"
-  checksum: 10/2e729631ae856bb4f2e7fcfd68100455656d2409ac6166ed6c9a0661dd83a42864c827e6a9a5a1df276c908356fe863ab9c44e0e4a8e9c226269c957e6a9195a
-  languageName: node
-  linkType: hard
-
 "react-colorful@npm:^5.6.1":
   version: 5.6.1
   resolution: "react-colorful@npm:5.6.1"
@@ -7661,7 +7645,6 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     prettier: "npm:^3.5.3"
     react: "npm:^19.1.0"
-    react-click-outside: "npm:^3.0.1"
     react-colorful: "npm:^5.6.1"
     react-dom: "npm:^19.1.0"
     react-ga4: "npm:^2.1.0"


### PR DESCRIPTION
# What changes are introduced?
updated dependencies caused page to crash if color picker is clicked

# Any screenshots?
