### PR TITLE
fix: update scale loader prop to be optional to fix breaking change

### DIFF
--- a/src/ScaleLoader.tsx
+++ b/src/ScaleLoader.tsx
@@ -21,7 +21,7 @@ function ScaleLoader({
   margin = 2,
   barCount = 5,
   ...additionalprops
-}: LoaderHeightWidthRadiusProps & { barCount: number }) {
+}: LoaderHeightWidthRadiusProps & { barCount?: number }) {
   const wrapper: React.CSSProperties = {
     display: "inherit",
     ...cssOverride,


### PR DESCRIPTION
# What changes are introduced?
to fix https://github.com/davidhu2000/react-spinners/pull/617#discussion_r2042941858

the prop should not be required

# Any screenshots?
