### PR TITLE
chore: add unnecessary files to npmignore 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -32,3 +32,9 @@ yarn-error.log
 .prettierignore
 test-apps
 tests
+CHANGELOG.md
+.yarnrc.yml
+.prettierrc.cjs
+tests/*
+scripts/*
+.vscode/*


### PR DESCRIPTION
# What changes are introduced?

| file | size|
|-|-|
CHANGELOG.md | 22.4 kB
.yarnrc.yml | 185 B
.prettierrc.cjs | 185 B
tests/* | 1.07 kB
scripts/* |  3.5 kB
.vscode/* | 130 B


this is ~27.5kb saved per download. 


this roughly saves to 13.5GB/week or 700GB/year of bandwidth 