### PR TITLE
chore: remove umd files from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
   "main": "index.js",
   "module": "esm/index.js",
   "scripts": {
-    "prepare": "$npm_execpath run build:cjs & $npm_execpath run build:esm & $npm_execpath run build:umd && $npm_execpath run build",
+    "prepare": "$npm_execpath run build:cjs & $npm_execpath run build:esm && $npm_execpath run build",
     "build": "tsc --project tsconfig.cjs.json",
     "build:cjs": "tsc --project tsconfig.cjs.json --outDir cjs",
     "build:esm": "tsc --project tsconfig.esm.json --outDir esm",
-    "build:umd": "tsc --project tsconfig.umd.json --outDir umd",
     "build:demo": "$npm_execpath run vite build",
     "dev:demo": "vite dev",
     "patch": "npm version patch && npm publish && npm run clean",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "patch": "npm version patch && npm publish && npm run clean",
     "minor": "npm version minor && npm publish && npm run clean",
     "major": "npm version major && npm publish && npm run clean",
-    "clean": "rm -rf helpers/; rm -f *Loader.js; rm -f *Loader.d.ts; rm -f index.js; rm -f index.d.ts; rm -rf docs/js; rm -rf cjs; rm -rf esm; rm -rf umd",
+    "clean": "rm -rf helpers/; rm -f *Loader.js; rm -f *Loader.d.ts; rm -f index.js; rm -f index.d.ts; rm -rf docs/js; rm -rf cjs; rm -rf esm",
     "lint": "eslint",
     "test": "jest",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",

--- a/tsconfig.umd.json
+++ b/tsconfig.umd.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "umd"
-  }
-}


### PR DESCRIPTION
# What changes are introduced?

umd isn't really useful for this package, as it can't run via a script tag 

```html
<script src="https://unpkg.com/react-spinners@latest/umd/react-spinners.min.js"></script>
```

due to the dependency on react. The `umd` folder is also `149 kB`, which is about 73.5GB of bandwidth a week, or 3.8TB a year.

also, searched for `https://unpkg.com/react-spinners` on google and github, didn't find anything, so we should be ok

# Any screenshots?
![Screenshot 2025-04-20 at 9 24 13 AM](https://github.com/user-attachments/assets/d375964f-021b-452a-b6ca-0291268c6bde)
