### PR TITLE
chore: revert cjs changes, remove `cjs` folder from build outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spinners",
-  "version": "0.17.0-beta.4",
+  "version": "0.17.0-beta.5",
   "description": "A collection of react loading spinners",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,22 +29,18 @@
     "progress",
     "activity"
   ],
-  "main": "cjs/index.js",
+  "main": "index.js",
   "module": "esm/index.js",
-  "exports": {
-    "import": "./esm/index.js",
-    "require": "./cjs/index.js"
-  },
   "scripts": {
-    "prepare": "$npm_execpath run clean && $npm_execpath run build:cjs & $npm_execpath run build:esm",
-    "build:cjs": "tsc --project tsconfig.cjs.json --outDir cjs",
+    "prepare": "$npm_execpath run clean && $npm_execpath run build && $npm_execpath run build:esm",
+    "build": "tsc --project tsconfig.cjs.json",
     "build:esm": "tsc --project tsconfig.esm.json --outDir esm",
     "build:demo": "$npm_execpath run vite build",
     "dev:demo": "vite dev",
     "patch": "npm version patch && npm publish && npm run clean",
     "minor": "npm version minor && npm publish && npm run clean",
     "major": "npm version major && npm publish && npm run clean",
-    "clean": "rm -rf cjs; rm -rf esm",
+    "clean": "rm -rf helpers/; rm -f *Loader.js; rm -f *Loader.d.ts; rm -f index.js; rm -f index.d.ts; rm -rf esm",
     "lint": "eslint",
     "test": "jest",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "tests",
     "examples",
     "src/*.test.tsx",
+    "src/helpers/*.test.*",
     "stories",
     "test-apps"
   ]


### PR DESCRIPTION
# What changes are introduced?


#647 didn't work, we can no longer import via path, so we need the files in the root directory. 

checking on pkg-size, looks like it break a few things

![Screenshot 2025-04-20 at 9 52 00 AM](https://github.com/user-attachments/assets/beac58d5-460d-4735-a7c6-ce2194a8d6d0)

https://pkg-size.dev/react-spinners@0.17.0-beta.4