### PR TITLE
chore: update readme example to not use path import

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each loader accepts a `loading` prop as a boolean. The loader will render `null`
 
 ```tsx
 import { useState, CSSProperties } from "react";
-import ClipLoader from "react-spinners/ClipLoader";
+import { ClipLoader } from "react-spinners";
 
 const override: CSSProperties = {
   display: "block",
@@ -62,7 +62,11 @@ function App() {
   return (
     <div className="sweet-loading">
       <button onClick={() => setLoading(!loading)}>Toggle Loader</button>
-      <input value={color} onChange={(input) => setColor(input.target.value)} placeholder="Color of the loader" />
+      <input
+        value={color}
+        onChange={(input) => setColor(input.target.value)}
+        placeholder="Color of the loader"
+      />
 
       <ClipLoader
         color={color}
@@ -83,7 +87,7 @@ export default App;
 
 ```tsx
 import React from "react";
-import ClipLoader from "react-spinners/ClipLoader";
+import { ClipLoader } from "react-spinners";
 
 const override: React.CSSProperties = {
   display: "block",


### PR DESCRIPTION
# What changes are introduced?

the original version was added before tree shaking worked on this package, now that it works, we don't need to recommend this old way of importing. 

# Any screenshots?
