### PR TITLE
fix: show Storybook primary stories only

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,8 +17,6 @@ module.exports = {
     disableTelemetry: true,
   },
 
-  docs: {},
-
   typescript: {
     reactDocgen: "react-docgen-typescript",
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,4 +27,3 @@ export const argTypes = {
     control: { type: "object" },
   },
 };
-export const tags = ["autodocs"];

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "remove:tag": "npm dist-tag rm react-spinners next",
     "publish:next": "npm publish --tag next && npm run clean",
-    "storybook": "storybook dev --docs -p 6006",
-    "build-storybook": "storybook build --docs -o ./dist/storybook"
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build -o ./dist/storybook"
   },
   "devDependencies": {
     "@storybook/addon-docs": "^10.6.0",

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 ruby scripts/stories.rb
-yarn run build-storybook --docs
+yarn run build-storybook


### PR DESCRIPTION
The Storybook deployment currently opens generated autodocs routes such as `/docs/bounceloader--docs`, but this project only defines a `Primary` story and the docs page renders no useful content.

Remove docs-only flags and global autodocs so the deployed Storybook exposes the primary Canvas stories directly.

The generated Storybook index was verified to contain 23 `--primary` entries and zero `--docs` entries.
