### PR TITLE
ci: publish npm releases with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: node .yarn/releases/yarn-4.18.0.cjs install --immutable
+      - name: Verify release version
+        run: node -e "const version = 'v' + require('./package.json').version; if (version !== process.env.GITHUB_REF_NAME) throw new Error('Expected tag ' + version + ', got ' + process.env.GITHUB_REF_NAME)"
+      - run: node .yarn/releases/yarn-4.18.0.cjs run lint --max-warnings=0
+      - run: node .yarn/releases/yarn-4.18.0.cjs run test --runInBand
+      - run: node .yarn/releases/yarn-4.18.0.cjs run prepare
+      - run: npm publish --ignore-scripts


### PR DESCRIPTION
# What changes are introduced?

Releases currently require publishing from a maintainer's machine. This adds an npm trusted-publishing workflow so stable GitHub Releases publish through short-lived OIDC credentials instead of a long-lived `NPM_TOKEN`.

The workflow checks that the release tag matches `package.json`, installs the locked dependency graph, runs lint and tests, builds both package formats, and publishes only after those checks pass. Actions remain pinned to exact commits and the job receives only read access plus OIDC permission.

After merge, npm must trust `davidhu2000/react-spinners` and workflow filename `publish.yml` before the first release.

# Proof

- Workflow YAML parses successfully.
- Version/tag guard passes for `v0.17.0`.
- Lint passes with zero warnings.
- All 115 tests pass.
- Package preparation succeeds.
- npm dry-run builds the expected package and stops only because `0.17.0` is already published.

# Any screenshots?

Not applicable.
